### PR TITLE
Match behaviour of the Escape key in vi

### DIFF
--- a/prompt_toolkit/key_bindings/vi.py
+++ b/prompt_toolkit/key_bindings/vi.py
@@ -76,6 +76,7 @@ def vi_bindings(registry, cli_ref):
             line.cursor_position -= 1
 
     @handle(Keys.Escape)
+    @handle(Keys.ControlSquareOpen)
     def _(event):
         """
         Escape goes to vi navigation mode.

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -50,6 +50,7 @@ class Keys(object):
     ControlSpace       = Key('<C-Space>')
     ControlBackslash   = Key('<C-Backslash>')
     ControlSquareClose = Key('<C-SquareClose>')
+    ControlSquareOpen  = Key('<C-SquareOpen>')
     ControlCircumflex  = Key('<C-Circumflex>')
     ControlUnderscore  = Key('<C-Underscore>')
 


### PR DESCRIPTION
`CTRL-[` is the same as `<Esc>` in vi, and either one moves the cursor to the left upon leaving insert mode.
