### PR TITLE
End with cursor on the most recently replaced character

### DIFF
--- a/prompt_toolkit/key_bindings/vi.py
+++ b/prompt_toolkit/key_bindings/vi.py
@@ -303,6 +303,7 @@ def vi_bindings(registry, cli_ref):
         Replace single character under cursor
         """
         line.insert_text(event.data * event.arg, overwrite=True)
+        line.cursor_position -= 1
 
     @handle('R', in_mode=InputMode.VI_NAVIGATION)
     def _(event):


### PR DESCRIPTION
After replacing characters with r or R, vi positions the cursor on the most recently replaced character.
