### PR TITLE
add 'j' and 'k' bindings to vi mode

### DIFF
--- a/prompt_toolkit/key_bindings/vi.py
+++ b/prompt_toolkit/key_bindings/vi.py
@@ -89,6 +89,20 @@ def vi_bindings(registry, cli_ref):
         else:
             event.input_processor.input_mode = InputMode.VI_NAVIGATION
 
+    @handle('k', in_mode=InputMode.VI_NAVIGATION)
+    def _(event):
+        """
+        Arrow up in navigation mode.
+        """
+        line.auto_up(count=event.arg)
+
+    @handle('j', in_mode=InputMode.VI_NAVIGATION)
+    def _(event):
+        """
+        Arrow down in navigation mode.
+        """
+        line.auto_down(count=event.arg)
+
     @handle(Keys.Up, in_mode=InputMode.VI_NAVIGATION)
     def _(event):
         """
@@ -826,12 +840,12 @@ def vi_bindings(registry, cli_ref):
         """ Implements 'ch', 'dh', 'h': Cursor left. """
         return CursorRegion(line.document.get_cursor_left_position(count=event.arg))
 
-    @change_delete_move_yank_handler('j')
+    @change_delete_move_yank_handler('j', no_move_handler=True)
     def _(event):
         """ Implements 'cj', 'dj', 'j', ... Cursor up. """
         return CursorRegion(line.document.get_cursor_down_position(count=event.arg))
 
-    @change_delete_move_yank_handler('k')
+    @change_delete_move_yank_handler('k', no_move_handler=True)
     def _(event):
         """ Implements 'ck', 'dk', 'k', ... Cursor up. """
         return CursorRegion(line.document.get_cursor_up_position(count=event.arg))


### PR DESCRIPTION
Just like in bash/zsh/readline this makes it possible to use j/k to navigate in the history
