### PR TITLE
Initialize IPython Extensions

### DIFF
--- a/prompt_toolkit/contrib/ipython.py
+++ b/prompt_toolkit/contrib/ipython.py
@@ -139,13 +139,18 @@ def initialize_extensions(shell, extensions):
     """
     Partial copy of `InteractiveShellApp.init_extensions` from IPython.
     """
-    for ext in extensions:
-        try:
-            shell.extension_manager.load_extension(ext)
-        except:
-            ipy_utils.warn.warn("Error in loading extension: %s" % ext +
-                 "\nCheck your config files in %s" % ipy_utils.path.get_ipython_dir())
-            shell.showtraceback()
+    try:
+        iter(extensions)
+    except TypeError:
+        pass  # no extensions found
+    else:
+        for ext in extensions:
+            try:
+                shell.extension_manager.load_extension(ext)
+            except:
+                ipy_utils.warn.warn("Error in loading extension: %s" % ext +
+                    "\nCheck your config files in %s" % ipy_utils.path.get_ipython_dir())
+                shell.showtraceback()
 
 
 def embed(**kwargs):


### PR DESCRIPTION
Initialization of ipython extensions (from user configuration) is not part of the embed process, so we'll have to do it manually.
