### PR TITLE
Add an argument to word_before_cursor to be WORD compatible.

### DIFF
--- a/prompt_toolkit/document.py
+++ b/prompt_toolkit/document.py
@@ -219,7 +219,7 @@ class Document(object):
         except StopIteration:
             pass
 
-    def get_word_before_cursor(self):
+    def get_word_before_cursor(self, WORD=False):
         """
         Give the word before the cursor.
         If we have whitespace before the cursor this returns an empty string.
@@ -227,7 +227,7 @@ class Document(object):
         if self.text_before_cursor[-1:].isspace():
             return ''
         else:
-            return self.text_before_cursor[self.find_start_of_previous_word():]
+            return self.text_before_cursor[self.find_start_of_previous_word(WORD=WORD):]
 
     def find_start_of_previous_word(self, count=1, WORD=False):
         """


### PR DESCRIPTION
This allows me to decide whether to include special characters when extracting the word_before_cursor(). 

This is useful if my cli has words with special characters. For example, postgres cli will have special commands such as `\dt`, in which case we want the word_before_cursor() to return the word including the character `\`. 
