### PR TITLE
Print warning when Pygments lexer swallows characters.

### DIFF
--- a/docs/pages/tutorials/repl.rst
+++ b/docs/pages/tutorials/repl.rst
@@ -98,7 +98,7 @@ wrapped into a :class:`~prompt_toolkit.lexers.PygmentsLexer`.
     from pygments.lexers import SqlLexer
 
     def main():
-        session = PromptSession(lexer=PygmentsLexer(SqlLexer)
+        session = PromptSession(lexer=PygmentsLexer(SqlLexer))
 
         while True:
             try:


### PR DESCRIPTION
## Description

When Pygments lexer swallows characters, users will find the text they typed disappear and the cursor will jump to the beginning of a line. It takes time to realize that it is because of Pygments lexer. So this PR printed a warning message when a lexer swallows characters.

Please refer to #658 for more information.
