### PR TITLE
RadioList: search

### DIFF
--- a/prompt_toolkit/shortcuts/dialogs.py
+++ b/prompt_toolkit/shortcuts/dialogs.py
@@ -201,6 +201,7 @@ def _create_app(dialog, style):
     bindings = KeyBindings()
     bindings.add('tab')(focus_next)
     bindings.add('s-tab')(focus_previous)
+    bindings.add('escape')(lambda x: _return_none())
 
     return Application(
         layout=Layout(dialog),


### PR DESCRIPTION
This PR genually improves RadioList by:
- binding the escapekey to cancel
- adding support for the `pageup` and `pagedown` keys
- adds a search system, demonstrated below

[![Prompt_toolkit RadioList.search v1](https://i.imgur.com/i9Q7xVY.png)](https://www.youtube.com/watch?v=RfzDHDBOqgA "Prompt_toolkit RadioList.search v1")

I'm of course open to any suggestions.

Note: I tried several implementations of the searching system. The first one aimed at adding `> [the text]` above or below the frame. However, due to how the scrolling is implemented, it was harder than expected, which is why I rolled-back to a simpler color-based searching system. I can elaborate if needed