### PR TITLE
Update asking_for_input.rst

### DIFF
--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -472,7 +472,7 @@ default. The following example has a history out of the box:
        session.prompt()
 
 To persist a history to disk, use a :class:`~prompt_toolkit.history.FileHistory`
-instead instead of the default
+instead of the default
 :class:`~prompt_toolkit.history.InMemoryHistory`. This history object can be
 passed either to a :class:`~prompt_toolkit.shortcuts.PromptSession` or to the
 :meth:`~prompt_toolkit.shortcuts.prompt` function. For instance:


### PR DESCRIPTION
fix typo.
> To persist a history to disk, use a `FileHistory` **instead instead** of the default `InMemoryHistory`. This history object can be passed either to a `PromptSession` or to the `prompt()` function.