### PR TITLE
fix CommandLineInterface to Application in doc and comments

### DIFF
--- a/docs/pages/advanced_topics/architecture.rst
+++ b/docs/pages/advanced_topics/architecture.rst
@@ -68,8 +68,7 @@ TODO: this is a little outdated.
         |
         |  Normally after every key press, the output will be
         |  rendered again. This happens in the event loop of
-        |  the `CommandLineInterface` where `Renderer.render` is
-        |  called.
+        |  the `Application` where `Renderer.render` is called.
         v
     +---------------------------------------------------------------+
     |     Layout                                                    |

--- a/docs/pages/full_screen_apps.rst
+++ b/docs/pages/full_screen_apps.rst
@@ -307,7 +307,7 @@ the key handler:
         Pressing Ctrl-Q will exit the user interface.
 
         Setting a return value means: quit the event loop that drives the user
-        interface and return this value from the `CommandLineInterface.run()` call.
+        interface and return this value from the `Application.run()` call. 
         """
         event.app.exit()
 

--- a/examples/full-screen/split-screen.py
+++ b/examples/full-screen/split-screen.py
@@ -105,7 +105,7 @@ def _(event):
     Pressing Ctrl-Q or Ctrl-C will exit the user interface.
 
     Setting a return value means: quit the event loop that drives the user
-    interface and return this value from the `CommandLineInterface.run()` call.
+    interface and return this value from the `Application.run()` call.
 
     Note that Ctrl-Q does not work on all terminals. Sometimes it requires
     executing `stty -ixon`.

--- a/examples/telnet/chat-app.py
+++ b/examples/telnet/chat-app.py
@@ -53,7 +53,7 @@ def interact(connection):
 
     _connections.append(connection)
     try:
-        # Set CommandLineInterface.
+        # Set Application.
         while True:
             try:
                 result = yield From(prompt(message=prompt_msg, async_=True))


### PR DESCRIPTION
I think that doc and comments should also be fixed, because Application has merged CommandLineInterface.
The notation of CommandLineInterface leads to a misunderstanding of beginners.
 
Sorry about minor thing. Thanks.