### PR TITLE
Call accept_handler before append_to_history in Buffer.validate_and_handle

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -1613,12 +1613,12 @@ class Buffer(object):
 
         # When the validation succeeded, accept the input.
         if valid:
-            self.append_to_history()
-
             if self.accept_handler:
                 keep_text = self.accept_handler(self)
             else:
                 keep_text = False
+
+            self.append_to_history()
 
             if not keep_text:
                 self.reset()


### PR DESCRIPTION
This was a regression from 6cfc3f3059db9816a09e2ff91a923897ceabdd10.

Without this, any changes made to the buffer text in the accept handler are
not reflected in the history. For instance, I call dedent(text).strip() in the
accept handler.