### PR TITLE
Add __slots__ to Suggestion and Completion to improve memory usage

### DIFF
--- a/prompt_toolkit/auto_suggest.py
+++ b/prompt_toolkit/auto_suggest.py
@@ -36,7 +36,7 @@ class Suggestion(object):
     :param text: The suggestion text.
     """
     __slots__ = ('text',)
-    
+
     def __init__(self, text):
         self.text = text
 

--- a/prompt_toolkit/auto_suggest.py
+++ b/prompt_toolkit/auto_suggest.py
@@ -35,6 +35,8 @@ class Suggestion(object):
 
     :param text: The suggestion text.
     """
+    __slots__ = ('text',)
+    
     def __init__(self, text):
         self.text = text
 

--- a/prompt_toolkit/completion/base.py
+++ b/prompt_toolkit/completion/base.py
@@ -32,6 +32,11 @@ class Completion(object):
     :param selected_style: Style string, used for a selected completion.
         This can override the `style` parameter.
     """
+    __slots__ = (
+        'text', 'start_position', '_display_meta', 'display', 'style',
+        'selected_style'
+    )
+    
     def __init__(self, text, start_position=0, display=None, display_meta=None,
                  style='', selected_style=''):
         assert isinstance(text, text_type)

--- a/prompt_toolkit/completion/base.py
+++ b/prompt_toolkit/completion/base.py
@@ -36,7 +36,7 @@ class Completion(object):
         'text', 'start_position', '_display_meta', 'display', 'style',
         'selected_style'
     )
-    
+
     def __init__(self, text, start_position=0, display=None, display_meta=None,
                  style='', selected_style=''):
         assert isinstance(text, text_type)


### PR DESCRIPTION
If you're creating a lot of these then the overhead of a complete object (with a `__dict__`) can be quite large. Using `slots` makes these objects a lot smaller.