### PR TITLE
Add Python 3.7 testing back to Travis, and enable pip caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: false
+dist: xenial
+sudo: required
+cache: pip
 language: python
 
 matrix:
   include:
+    - python: 3.7
     - python: 3.6
     - python: 3.5
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-dist: xenial
-sudo: required
 cache: pip
 language: python
 
 matrix:
   include:
     - python: 3.7
+      dist: xenial
+      sudo: required
     - python: 3.6
     - python: 3.5
     - python: 3.4
@@ -16,7 +16,7 @@ matrix:
     - python: pypy3
 
 install:
-  - pip install . pytest coverage codecov flake8
+  - pip install . pytest coverage codecov flake8 pytest-xdist
   - pip list
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 cache: pip
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: pypy3
 
 install:
-  - pip install . pytest coverage codecov flake8 pytest-xdist
+  - pip install . pytest coverage codecov flake8
   - pip list
 
 script:


### PR DESCRIPTION
3.7 is available with the `xenial` image 🎉 

~It requires `sudo`, but seeing as Travis is deprecating the `sudo: false` containers anyway it's not a big deal?~ Edit: that causes 2.7 and pypy to break. So lets just use it in the 3.7 build 👍 