### PR TITLE
Fix typo in "Asking for input" tutorial

### DIFF
--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -196,7 +196,7 @@ Coloring the prompt itself
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is possible to add some colors to the prompt itself. For this, we need to
-build some :ref:`formatted text <formatted_text>`. One way of doing is is by
+build some :ref:`formatted text <formatted_text>`. One way of doing this is by
 creating a list of style/text tuples. In the following example, we use class
 names to refer to the style.
 


### PR DESCRIPTION
Fixed typo: `One way of doing is is` -> ` One way of doing this is`