### PR TITLE
Fixed WordCompleter when line ends with a space

### DIFF
--- a/prompt_toolkit/document.py
+++ b/prompt_toolkit/document.py
@@ -415,14 +415,20 @@ class Document(object):
         :param pattern: (None or compiled regex). When given, use this regex
             pattern.
         """
-        text_before_cursor = self.text_before_cursor
-        start = self.find_start_of_previous_word(WORD=WORD, pattern=pattern)
-
-        if start is None:
+        if self._is_word_before_cursor_complete(WORD=WORD, pattern=pattern):
             # Space before the cursor or no text before cursor.
             return ''
 
+        text_before_cursor = self.text_before_cursor
+        start = self.find_start_of_previous_word(WORD=WORD, pattern=pattern)
+
         return text_before_cursor[len(text_before_cursor) + start:]
+
+    def _is_word_before_cursor_complete(self, WORD=False, pattern=None):
+        if pattern:
+            return self.find_start_of_previous_word(pattern=pattern) is None
+        else:
+            return self.text_before_cursor == '' or self.text_before_cursor[-1:].isspace()
 
     def find_start_of_previous_word(self, count=1, WORD=False, pattern=None):
         """

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -265,6 +265,10 @@ def test_word_completer_static_word_list():
     completions = completer.get_completions(Document('A'), CompleteEvent())
     assert [c.text for c in completions] == []
 
+    # Multiple words ending with space. (Accept all options)
+    completions = completer.get_completions(Document('test '), CompleteEvent())
+    assert [c.text for c in completions] == ['abc', 'def', 'aaa']
+
     # Multiple words. (Check last only.)
     completions = completer.get_completions(Document('test a'), CompleteEvent())
     assert [c.text for c in completions] == ['abc', 'aaa']
@@ -346,3 +350,11 @@ def test_fuzzy_completer():
 
     completions = completer.get_completions(Document('miGr'), CompleteEvent())
     assert [c.text for c in completions] == ['migrations.py', 'django_migrations.py',]
+
+    # Multiple words ending with space. (Accept all options)
+    completions = completer.get_completions(Document('test '), CompleteEvent())
+    assert [c.text for c in completions] == collection
+
+    # Multiple words. (Check last only.)
+    completions = completer.get_completions(Document('test txt'), CompleteEvent())
+    assert [c.text for c in completions] == ['users.txt', 'accounts.txt']


### PR DESCRIPTION
This fixes the issue I reported in https://github.com/prompt-toolkit/python-prompt-toolkit/issues/837 .

I added unittests both for the WordCompleter and the FuzzyCompleter to ensure they properly work now.