### PR TITLE
Fix width computation in Progress Formatter

### DIFF
--- a/prompt_toolkit/shortcuts/progress_bar/formatters.py
+++ b/prompt_toolkit/shortcuts/progress_bar/formatters.py
@@ -168,7 +168,7 @@ class Progress(Formatter):
             total=progress.total or '?')
 
     def get_width(self, progress_bar):
-        all_lengths = [len('{0}'.format(c.total)) for c in progress_bar.counters]
+        all_lengths = [len('{0:>3}'.format(c.total)) for c in progress_bar.counters]
         all_lengths.append(1)
         return D.exact(max(all_lengths) * 2 + 1)
 


### PR DESCRIPTION
It used to print with replacement field {:>3} but compute width with {}.
Consequently, short numbers (<= 2 digits) were computed to have length
less than or equal to 2 but printed as 3 characters, and so, not
displayed properly.
To reproduce (almost the example of the doc):
```python
from prompt_toolkit.shortcuts import ProgressBar
import time


with ProgressBar() as pb:
    for i in pb(range(99)):
        time.sleep(.01)
```
but it does not happen if we replace 99 by 100 (or 800, as in the doc), for instance. Of course, with a 1 digit number, it's even worse.

Since 3 is the smallest length possible, we could as well append 3 rather than 1 at the next line. Though I find this way less understandable.

Also, the '>' is not necessary, but I want to make clear that it is the same replacement field as in the template.