### PR TITLE
Add pattern to WorldCompleter's constructor

### DIFF
--- a/prompt_toolkit/completion/word_completer.py
+++ b/prompt_toolkit/completion/word_completer.py
@@ -23,9 +23,11 @@ class WordCompleter(Completer):
         contain spaces. (Can not be used together with the WORD option.)
     :param match_middle: When True, match not only the start, but also in the
                          middle of the word.
+    :param pattern: Optional regex. When given, use this regex
+        pattern instead of default one.
     """
     def __init__(self, words, ignore_case=False, meta_dict=None, WORD=False,
-                 sentence=False, match_middle=False):
+                 sentence=False, match_middle=False, pattern=None):
         assert not (WORD and sentence)
         assert callable(words) or all(isinstance(w, string_types) for w in words)
 
@@ -35,6 +37,7 @@ class WordCompleter(Completer):
         self.WORD = WORD
         self.sentence = sentence
         self.match_middle = match_middle
+        self.pattern = pattern
 
     def get_completions(self, document, complete_event):
         # Get list of words.
@@ -46,7 +49,7 @@ class WordCompleter(Completer):
         if self.sentence:
             word_before_cursor = document.text_before_cursor
         else:
-            word_before_cursor = document.get_word_before_cursor(WORD=self.WORD)
+            word_before_cursor = document.get_word_before_cursor(WORD=self.WORD, pattern=self.pattern)
 
         if self.ignore_case:
             word_before_cursor = word_before_cursor.lower()

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
 import os
+import re
 import shutil
 import tempfile
 
@@ -318,6 +319,19 @@ def test_word_completer_dynamic_word_list():
     completions = completer.get_completions(Document('a'), CompleteEvent())
     assert [c.text for c in completions] == ['abc', 'aaa']
     assert called[0] == 2
+
+
+def test_word_completer_pattern():
+    # With a pattern which support '.'
+    completer = WordCompleter(['abc', 'a.b.c', 'a.b', 'xyz'],
+                              pattern=re.compile(r'^([a-zA-Z0-9_.]+|[^a-zA-Z0-9_.\s]+)'))
+    completions = completer.get_completions(Document('a.'), CompleteEvent())
+    assert [c.text for c in completions] == ['a.b.c', 'a.b']
+
+    # Without pattern
+    completer = WordCompleter(['abc', 'a.b.c', 'a.b', 'xyz'])
+    completions = completer.get_completions(Document('a.'), CompleteEvent())
+    assert [c.text for c in completions] == []
 
 
 def test_fuzzy_completer():


### PR DESCRIPTION
add pattern to WordCompleter's constructor in order to pass it to document.get_word_before_cursor in get_completions method.
A test added for it.