### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'six>=1.9.0',
         'wcwidth',
     ],
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This lets pip install the right release of the package for the running Python.