### PR TITLE
Add PROMPT_TOOLKIT_NO_CPR=1 environment variable to disable CPR requests (2.0)

### DIFF
--- a/prompt_toolkit/input/vt100.py
+++ b/prompt_toolkit/input/vt100.py
@@ -69,6 +69,8 @@ class Vt100Input(Input):
     def responds_to_cpr(self):
         # When the input is a tty, we assume that CPR is supported.
         # It's not when the input is piped from Pexpect.
+        if os.environ.get('PROMPT_TOOLKIT_NO_CPR', '') == '1':
+            return False
         return self.stdin.isatty()
 
     def attach(self, input_ready_callback):


### PR DESCRIPTION
Add PROMPT_TOOLKIT_NO_CPR=1 environment variable to disable CPR requests.

See https://github.com/prompt-toolkit/python-prompt-toolkit/issues/886#issuecomment-490274914.