### PR TITLE
Add PROMPT_TOOLKIT_NO_CPR=1 environment variable to disable CPR requests (master)

### DIFF
--- a/prompt_toolkit/input/vt100.py
+++ b/prompt_toolkit/input/vt100.py
@@ -81,6 +81,8 @@ class Vt100Input(Input):
     def responds_to_cpr(self) -> bool:
         # When the input is a tty, we assume that CPR is supported.
         # It's not when the input is piped from Pexpect.
+        if os.environ.get('PROMPT_TOOLKIT_NO_CPR', '') == '1':
+            return False
         try:
             return self.stdin.isatty()
         except ValueError:


### PR DESCRIPTION
Same as https://github.com/prompt-toolkit/python-prompt-toolkit/pull/897 execpt against master.

I've tested https://github.com/prompt-toolkit/python-prompt-toolkit/pull/897 and can confirm it works, but I have not tested the master version (this branch). 