### PR TITLE
Remove no-\r assertion in print_formatted_text

### DIFF
--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -684,7 +684,7 @@ def print_formatted_text(
         else:
             output.reset_attributes()
 
-        # Eliminate newlines
+        # Eliminate carriage returns
         text = text.replace('\r', '')
 
         # Assume that the output is raw, and insert a carriage return before

--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -684,9 +684,11 @@ def print_formatted_text(
         else:
             output.reset_attributes()
 
+        # Eliminate newlines
+        text = text.replace('\r', '')
+
         # Assume that the output is raw, and insert a carriage return before
         # every newline. (Also important when the front-end is a telnet client.)
-        assert '\r' not in text
         output.write(text.replace('\n', '\r\n'))
 
     # Reset again.

--- a/tests/test_print_formatted_text.py
+++ b/tests/test_print_formatted_text.py
@@ -49,6 +49,12 @@ def test_print_formatted_text():
     assert b'hello' in f.data
     assert b'world' in f.data
 
+@pytest.mark.skipif(
+    is_windows(), reason="Doesn't run on Windows yet.")
+def test_print_formatted_text_backslash_r():
+    f = _Capture()
+    pt_print('hello\r\n', file=f)
+    assert b'hello' in f.data
 
 @pytest.mark.skipif(
     is_windows(), reason="Doesn't run on Windows yet.")


### PR DESCRIPTION
Follow up from https://github.com/prompt-toolkit/python-prompt-toolkit/issues/915

I'll go ahead and submit a similar PR for 2.0 branch once this one's accepted.