### PR TITLE
Make sure HANDLE  on Windows has a correct size

### DIFF
--- a/prompt_toolkit/eventloop/win32.py
+++ b/prompt_toolkit/eventloop/win32.py
@@ -36,7 +36,7 @@ class Win32EventLoop(EventLoop):
     def __init__(self, inputhook=None, recognize_paste=True):
         assert inputhook is None or callable(inputhook)
 
-        self._event = _create_event()
+        self._event = HANDLE(_create_event())
         self._console_input_reader = ConsoleInputReader(recognize_paste=recognize_paste)
         self._calls_from_executor = []
 
@@ -74,14 +74,14 @@ class Win32EventLoop(EventLoop):
             # Wait for the next event.
             handle = self._ready_for_reading(remaining_timeout)
 
-            if handle == self._console_input_reader.handle:
+            if handle == self._console_input_reader.handle.value:
                 # When stdin is ready, read input and reset timeout timer.
                 keys = self._console_input_reader.read()
                 for k in keys:
                     callbacks.feed_key(k)
                 current_timeout = INPUT_TIMEOUT_MS
 
-            elif handle == self._event:
+            elif handle == self._event.value:
                 # When the Windows Event has been trigger, process the messages in the queue.
                 windll.kernel32.ResetEvent(self._event)
                 self._process_queued_calls_from_executor()

--- a/prompt_toolkit/terminal/win32_input.py
+++ b/prompt_toolkit/terminal/win32_input.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from ctypes import windll, pointer
-from ctypes.wintypes import DWORD
+from ctypes.wintypes import DWORD, HANDLE
 from six.moves import range
 
 from prompt_toolkit.key_binding.input_processor import KeyPress
@@ -111,10 +111,10 @@ class ConsoleInputReader(object):
         # When stdin is a tty, use that handle, otherwise, create a handle from
         # CONIN$.
         if sys.stdin.isatty():
-            self.handle = windll.kernel32.GetStdHandle(STD_INPUT_HANDLE)
+            self.handle = HANDLE(windll.kernel32.GetStdHandle(STD_INPUT_HANDLE))
         else:
             self._fdcon = os.open('CONIN$', os.O_RDWR | os.O_BINARY)
-            self.handle = msvcrt.get_osfhandle(self._fdcon)
+            self.handle = HANDLE(msvcrt.get_osfhandle(self._fdcon))
 
     def close(self):
         " Close fdcon. "
@@ -321,7 +321,7 @@ class raw_mode(object):
     `raw_input` method of `.vt100_input`.
     """
     def __init__(self, fileno=None):
-        self.handle = windll.kernel32.GetStdHandle(STD_INPUT_HANDLE)
+        self.handle = HANDLE(windll.kernel32.GetStdHandle(STD_INPUT_HANDLE))
 
     def __enter__(self):
         # Remember original mode.

--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from ctypes import windll, byref, ArgumentError, c_char, c_long, c_ulong, c_uint, pointer
-from ctypes.wintypes import DWORD
+from ctypes.wintypes import DWORD, HANDLE
 
 from prompt_toolkit.renderer import Output
 from prompt_toolkit.styles import ANSI_COLOR_NAMES
@@ -70,7 +70,7 @@ class Win32Output(Output):
 
         self._buffer = []
         self.stdout = stdout
-        self.hconsole = windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+        self.hconsole = HANDLE(windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE))
 
         self._in_alternate_screen = False
 
@@ -346,8 +346,8 @@ class Win32Output(Output):
             GENERIC_WRITE = 0x40000000
 
             # Create a new console buffer and activate that one.
-            handle = self._winapi(windll.kernel32.CreateConsoleScreenBuffer, GENERIC_READ|GENERIC_WRITE,
-                                  DWORD(0), None, DWORD(1), None)
+            handle = HANDLE(self._winapi(windll.kernel32.CreateConsoleScreenBuffer, GENERIC_READ|GENERIC_WRITE,
+                                         DWORD(0), None, DWORD(1), None))
 
             self._winapi(windll.kernel32.SetConsoleActiveScreenBuffer, handle)
             self.hconsole = handle
@@ -358,7 +358,7 @@ class Win32Output(Output):
         Make stdout again the active buffer.
         """
         if self._in_alternate_screen:
-            stdout = self._winapi(windll.kernel32.GetStdHandle, STD_OUTPUT_HANDLE)
+            stdout = HANDLE(self._winapi(windll.kernel32.GetStdHandle, STD_OUTPUT_HANDLE))
             self._winapi(windll.kernel32.SetConsoleActiveScreenBuffer, stdout)
             self._winapi(windll.kernel32.CloseHandle, self.hconsole)
             self.hconsole = stdout
@@ -366,7 +366,7 @@ class Win32Output(Output):
 
     def enable_mouse_support(self):
         ENABLE_MOUSE_INPUT = 0x10
-        handle = windll.kernel32.GetStdHandle(STD_INPUT_HANDLE)
+        handle = HANDLE(windll.kernel32.GetStdHandle(STD_INPUT_HANDLE))
 
         original_mode = DWORD()
         self._winapi(windll.kernel32.GetConsoleMode, handle, pointer(original_mode))
@@ -374,7 +374,7 @@ class Win32Output(Output):
 
     def disable_mouse_support(self):
         ENABLE_MOUSE_INPUT = 0x10
-        handle = windll.kernel32.GetStdHandle(STD_INPUT_HANDLE)
+        handle = HANDLE(windll.kernel32.GetStdHandle(STD_INPUT_HANDLE))
 
         original_mode = DWORD()
         self._winapi(windll.kernel32.GetConsoleMode, handle, pointer(original_mode))
@@ -396,7 +396,7 @@ class Win32Output(Output):
         to a bug in the Windows Console. Sending a repaint request solves it.
         """
         # Get console handle
-        handle = windll.kernel32.GetConsoleWindow()
+        handle = HANDLE(windll.kernel32.GetConsoleWindow())
 
         RDW_INVALIDATE = 0x0001
         windll.user32.RedrawWindow(handle, None, None, c_uint(RDW_INVALIDATE))


### PR DESCRIPTION
Previously, the type of various HANDLEs are native Python integer types.
The ctypes library will treat them as 4-byte integer when used in function
arguments. On 64-bit Windows, HANDLE is 8-byte and usually a small integer.
Depending on whether the extra 4 bytes are zero-ed out or not, things can
happen to work, or break.

This patch adds type casting so ctypes uses 8-byte integers for HANDLEs
on 64-bit Windows.

Fixes #406.

This pull request is based on the 1.0 branch, since that's used by the
last IPython release for Python 2 and we're currently using IPython
+python2 (64bit MSVC2017 build).