### PR TITLE
Added stop_time to ProgressBarCounter

### DIFF
--- a/prompt_toolkit/shortcuts/progress_bar/base.py
+++ b/prompt_toolkit/shortcuts/progress_bar/base.py
@@ -307,6 +307,7 @@ class ProgressBarCounter(Generic[_CounterItem]):
                  total: Optional[int] = None) -> None:
 
         self.start_time = datetime.datetime.now()
+        self.stop_time = None
         self.progress_bar = progress_bar
         self.data = data
         self.items_completed = 0
@@ -349,6 +350,10 @@ class ProgressBarCounter(Generic[_CounterItem]):
     def done(self, value: bool) -> None:
         self._done = value
 
+        # if declared done then store the stop_time
+        # otherwise clear the stop_time
+        self.stop_time = datetime.datetime.now() if value else None
+
         if value and self.remove_when_done:
             self.progress_bar.counters.remove(self)
 
@@ -364,7 +369,10 @@ class ProgressBarCounter(Generic[_CounterItem]):
         """
         return how much time has been elapsed since the start.
         """
-        return datetime.datetime.now() - self.start_time
+        if self.stop_time is None:
+            return datetime.datetime.now() - self.start_time
+        else:
+            return self.stop_time - self.start_time
 
     @property
     def time_left(self) -> Optional[datetime.timedelta]:

--- a/prompt_toolkit/shortcuts/progress_bar/base.py
+++ b/prompt_toolkit/shortcuts/progress_bar/base.py
@@ -307,7 +307,7 @@ class ProgressBarCounter(Generic[_CounterItem]):
                  total: Optional[int] = None) -> None:
 
         self.start_time = datetime.datetime.now()
-        self.stop_time = None
+        self.stop_time: Optional[datetime.datetime] = None
         self.progress_bar = progress_bar
         self.data = data
         self.items_completed = 0
@@ -350,8 +350,7 @@ class ProgressBarCounter(Generic[_CounterItem]):
     def done(self, value: bool) -> None:
         self._done = value
 
-        # if declared done then store the stop_time
-        # otherwise clear the stop_time
+        # If done then store the stop_time, otherwise clear.
         self.stop_time = datetime.datetime.now() if value else None
 
         if value and self.remove_when_done:
@@ -367,7 +366,7 @@ class ProgressBarCounter(Generic[_CounterItem]):
     @property
     def time_elapsed(self) -> datetime.timedelta:
         """
-        return how much time has been elapsed since the start.
+        Return how much time has been elapsed since the start.
         """
         if self.stop_time is None:
             return datetime.datetime.now() - self.start_time


### PR DESCRIPTION
When using ProgressBars it makes sense for elapsed time to stop incrementing once the counter in question finishes.