### PR TITLE
Two minor tweaks to widgets/base

### DIFF
--- a/examples/dialogs/checkbox_dialog.py
+++ b/examples/dialogs/checkbox_dialog.py
@@ -2,6 +2,7 @@
 """
 Example of a checkbox-list-based dialog.
 """
+from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.shortcuts import checkboxlist_dialog, message_dialog
 from prompt_toolkit.styles import Style
 
@@ -13,6 +14,7 @@ results = checkboxlist_dialog(
         ("bacon", "Bacon"),
         ("croissants", "20 Croissants"),
         ("daily", "The breakfast of the day"),
+        ("horse", HTML("<style fg='red'>Equestrian</style>")),
     ],
     style=Style.from_dict(
         {

--- a/prompt_toolkit/formatted_text/__init__.py
+++ b/prompt_toolkit/formatted_text/__init__.py
@@ -27,6 +27,7 @@ from .utils import (
     fragment_list_to_text,
     fragment_list_width,
     split_lines,
+    to_str,
 )
 
 __all__ = [
@@ -49,4 +50,5 @@ __all__ = [
     "fragment_list_width",
     "fragment_list_to_text",
     "split_lines",
+    "to_str",
 ]

--- a/prompt_toolkit/formatted_text/utils.py
+++ b/prompt_toolkit/formatted_text/utils.py
@@ -4,17 +4,28 @@ Utilities for manipulating formatted text.
 When ``to_formatted_text`` has been called, we get a list of ``(style, text)``
 tuples. This file contains functions for manipulating such a list.
 """
-from typing import Iterable, cast
+from typing import (
+    cast,
+    Callable,
+    Iterable,
+    Union
+)
 
 from prompt_toolkit.utils import get_cwidth
 
-from .base import OneStyleAndTextTuple, StyleAndTextTuples
+from .base import (
+    AnyFormattedText,
+    OneStyleAndTextTuple,
+    StyleAndTextTuples,
+    to_formatted_text,
+)
 
 __all__ = [
     "fragment_list_len",
     "fragment_list_width",
     "fragment_list_to_text",
     "split_lines",
+    "to_str",
 ]
 
 
@@ -83,3 +94,19 @@ def split_lines(fragments: StyleAndTextTuples) -> Iterable[StyleAndTextTuples]:
     # line is yielded. (Otherwise, there's no way to differentiate between the
     # cases where `fragments` does and doesn't end with a newline.)
     yield line
+
+
+def to_str(value: Union[Callable[[], str], AnyFormattedText]) -> str:
+    """
+    Converts a formatted (or not) string to string.
+
+    This is useful when the input type is unknown, and
+    may or not be formatted.
+
+    :param value: the object to convert
+    """
+    if callable(value):
+        return to_str(value())
+    return fragment_list_to_text(
+        to_formatted_text(value)
+    )

--- a/prompt_toolkit/utils.py
+++ b/prompt_toolkit/utils.py
@@ -272,11 +272,13 @@ def take_using_weights(
 
 
 def to_str(value: Union[Callable[[], str], str]) -> str:
-    " Turn callable or string into string. "
-    if callable(value):
-        return to_str(value())
-    else:
-        return str(value)
+    """
+    Turn callable, formatted text or string into string
+.
+    :param value: the value to convert
+    """
+    from prompt_toolkit.formatted_text.utils import to_str as t
+    return t(value)
 
 
 def to_int(value: Union[Callable[[], int], int]) -> int:

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -33,6 +33,7 @@ from prompt_toolkit.formatted_text import (
     StyleAndTextTuples,
     Template,
     to_formatted_text,
+    to_str,
 )
 from prompt_toolkit.formatted_text.utils import fragment_list_to_text
 from prompt_toolkit.history import History
@@ -681,7 +682,7 @@ class _DialogList(Generic[_T]):
         def _(event: E) -> None:
             # We first check values after the selected value, then all values.
             for value in self.values[self._selected_index + 1 :] + self.values:
-                if value[1].startswith(event.data):
+                if to_str(value[1]).startswith(event.data):
                     self._selected_index = self.values.index(value)
                     return
 
@@ -804,7 +805,7 @@ class Checkbox(CheckboxList[str]):
         return "value" in self.current_values
 
 
-class VerticalLine(object):
+class VerticalLine:
     """
     A simple vertical line with a width of 1.
     """


### PR DESCRIPTION
This PR:
- updates GOTO-key in `_DialogList`
- implements the `to_str` util 
- removes a leftover class tag

About the first point, creating a `CheckBoxList` with content that is formatted (for instance that has `HTML()` in it) will make it crash. This made those lists very unstable (any key would crash)...

It was a rather low-effort implementation anyways: it should be reimplemented using a fancy search toolbar.