### PR TITLE
Remove redundant license parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     name='prompt_toolkit',
     author='Jonathan Slenders',
     version=get_version('prompt_toolkit'),
-    license='BSD-3-Clause',
     url='https://github.com/prompt-toolkit/python-prompt-toolkit',
     description='Library for building powerful interactive command lines in Python',
     long_description=long_description,


### PR DESCRIPTION
The [Python packaging specifications](https://packaging.python.org/specifications/core-metadata) indicate that the [`license` parameter](https://packaging.python.org/specifications/core-metadata/#license) to `setup()` should be used in one of the following cases:

* the license is not a selection from the “License” Trove classifiers
* to specify a particular version of a license which is named via the `Classifier` field
* to indicate a variation or exception to such a license

This PR removes the explicit `license` parameter since the usage for this project does not fit any of those cases and it makes it more difficult to use tools like [pip-licenses](https://pypi.org/project/pip-licenses) since it is not consistent with other projects that just have `License :: OSI Approved :: BSD License` as one of their trove classifiers.

Please note that this does _not_ change the license of the project in any way, and since this project already has a `License :: OSI Approved :: BSD License` trove classifier the `license` parameter is redundant.