### PR TITLE
Allow empty continuation

### DIFF
--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -1117,7 +1117,7 @@ class PromptSession(Generic[_T]):
 
         # When the continuation prompt is not given, choose the same width as
         # the actual prompt.
-        if not continuation and is_true(self.multiline):
+        if not continuation and continuation != '' and is_true(self.multiline):
             continuation = ' ' * width
 
         return to_formatted_text(

--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -1117,7 +1117,7 @@ class PromptSession(Generic[_T]):
 
         # When the continuation prompt is not given, choose the same width as
         # the actual prompt.
-        if not continuation and continuation != '' and is_true(self.multiline):
+        if continuation is None and is_true(self.multiline):
             continuation = ' ' * width
 
         return to_formatted_text(


### PR DESCRIPTION
If continuation is an empty string, instead of ignoring it and aligning with spaces, honor the non-None but empty value and don't align to the prompt width with spaces.

This is helpful if you want to configure your prompt to allow multiline editing and also want to copy the text directly from your terminal.