### PR TITLE
[WIP] Use asyncio.run().

### DIFF
--- a/examples/prompts/asyncio-prompt.py
+++ b/examples/prompts/asyncio-prompt.py
@@ -49,16 +49,17 @@ async def interactive_shell():
             return
 
 
-def main():
+async def main():
     with patch_stdout():
-        shell_task = asyncio.ensure_future(interactive_shell())
-        background_task = asyncio.gather(print_counter(), return_exceptions=True)
-
-        loop.run_until_complete(shell_task)
+        background_task = asyncio.ensure_future(print_counter())
+        await interactive_shell()
         background_task.cancel()
-        loop.run_until_complete(background_task)
-        print('Quitting event loop. Bye.')
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        from asyncio import run
+    except ImportError:
+        asyncio.get_event_loop().run_until_complete(main())
+    else:
+        run(main())

--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -290,8 +290,8 @@ class Buffer:
             self._working_lines.insert(0, self.history.get_strings()[0])
             self.__working_index += 1
 
+        # The history is loaded in Application.run_async. Handle loading here.
         self.history.get_item_loaded_event().add_handler(new_history_item)
-        self.history.start_loading()
 
     def __repr__(self) -> str:
         if len(self.text) < 15:

--- a/prompt_toolkit/history.py
+++ b/prompt_toolkit/history.py
@@ -62,6 +62,7 @@ class History(metaclass=ABCMeta):
             self._loading = True
             get_app().create_background_task(self._start_loading())
 
+
     def get_item_loaded_event(self) -> Event['History']:
         " Event which is triggered when a new item is loaded. "
         return self._item_loaded

--- a/prompt_toolkit/layout/layout.py
+++ b/prompt_toolkit/layout/layout.py
@@ -80,6 +80,11 @@ class Layout:
         for container in self.find_all_windows():
             yield container.content
 
+    def find_all_buffers(self) -> Iterable[Buffer]:
+        for control in self.find_all_controls():
+            if isinstance(control, BufferControl):
+                yield control.buffer
+
     def focus(self, value: FocusableElement) -> None:
         """
         Focus the given UI element.


### PR DESCRIPTION
This is not correct yet, check the persistent-history example:
```
 $ python examples/prompts/history/persistent-history.py
Say something: oaeu
You said: oaeu
Traceback (most recent call last):
  File "examples/prompts/history/persistent-history.py", line 25, in <module>
    main()
  File "examples/prompts/history/persistent-history.py", line 20, in main
    text = session.prompt('Say something: ')
  File "/home/jonathan/git/python-prompt-toolkit/prompt_toolkit/shortcuts/prompt.py", line 925, in prompt
    return self.app.run()
  File "/home/jonathan/git/python-prompt-toolkit/prompt_toolkit/application/application.py", line 754, in run
    loop = get_event_loop()
  File "/usr/lib/python3.7/asyncio/events.py", line 644, in get_event_loop
    % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.
```

Also, this doesn't work if new buffers are attached dynamically to the layout.