### PR TITLE
Tell black to use 150 line-length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 target-version = ['py36']
-
+line-length = 150
 
 [tool.isort]
 # isort configuration that is compatible with Black.


### PR DESCRIPTION
Currently, only flake8 is aware of the 150 line-length rule:
https://github.com/prompt-toolkit/python-prompt-toolkit/blob/7d2ef1998d0eb1ba268e9781be84051f35203b5d/setup.cfg#L1-L3

Need to also specify in pyproject.toml for black to know about it (or at least for Sublime Text's black plugin to know about it).