### PR TITLE
[wip] ProgressBar with callable remove_when_done

### DIFF
--- a/examples/progress-bar/a-lot-of-parallel-tasks.py
+++ b/examples/progress-bar/a-lot-of-parallel-tasks.py
@@ -16,8 +16,28 @@ def main():
         bottom_toolbar=HTML("<b>[Control-L]</b> clear  <b>[Control-C]</b> abort"),
     ) as pb:
 
+        lock = threading.Lock()
+        completed = []
+
+        # Remove a completed counter after 5 seconds but keep the last 5.
+        def remove_when_done(counter):
+            counter.label = "Completed"
+            with lock:
+                completed.append(counter)
+            time.sleep(5)
+            counter.progress_bar.invalidate()
+            while True:
+                if len(completed) < 5:
+                    pass
+                else:
+                    if completed[0] is counter:
+                        with lock:
+                            completed.pop(0)
+                        return True
+                time.sleep(1)
+
         def run_task(label, total, sleep_time):
-            for i in pb(range(total), label=label):
+            for i in pb(range(total), label=label, remove_when_done=remove_when_done):
                 time.sleep(sleep_time)
 
         threads = []

--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -91,9 +91,7 @@ except ImportError:
     import prompt_toolkit.eventloop.dummy_contextvars as contextvars  # type: ignore
 
 
-__all__ = [
-    "Application",
-]
+__all__ = ["Application"]
 
 
 E = KeyPressEvent
@@ -818,14 +816,15 @@ class Application(Generic[_AppResult]):
         ensure_future(in_term())
 
     def create_background_task(
-        self, coroutine: Awaitable[None]
+        self, coroutine: Awaitable[None], *, loop: Optional[AbstractEventLoop] = None
     ) -> "asyncio.Task[None]":
         """
         Start a background task (coroutine) for the running application.
         If asyncio had nurseries like Trio, we would create a nursery in
         `Application.run_async`, and run the given coroutine in that nursery.
         """
-        task = get_event_loop().create_task(coroutine)
+        loop = loop or get_event_loop()
+        task = loop.create_task(coroutine)
         self.background_tasks.append(task)
         return task
 

--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -816,15 +816,14 @@ class Application(Generic[_AppResult]):
         ensure_future(in_term())
 
     def create_background_task(
-        self, coroutine: Awaitable[None], *, loop: Optional[AbstractEventLoop] = None
+        self, coroutine: Awaitable[None]
     ) -> "asyncio.Task[None]":
         """
         Start a background task (coroutine) for the running application.
         If asyncio had nurseries like Trio, we would create a nursery in
         `Application.run_async`, and run the given coroutine in that nursery.
         """
-        loop = loop or get_event_loop()
-        task = loop.create_task(coroutine)
+        task = get_event_loop().create_task(coroutine)
         self.background_tasks.append(task)
         return task
 

--- a/prompt_toolkit/shortcuts/progress_bar/base.py
+++ b/prompt_toolkit/shortcuts/progress_bar/base.py
@@ -385,7 +385,9 @@ class ProgressBarCounter(Generic[_CounterItem]):
         if value:
             if callable(self.remove_when_done):
                 # Register a background task to run the remove_when_done callable.
-                get_app().create_background_task(self._remove_when_done_async())
+                self.progress_bar.app.create_background_task(
+                    self._remove_when_done_async(), loop=self.progress_bar._app_loop
+                )
             elif self.remove_when_done:
                 # Non-callable that is True, remove bar.
                 self.progress_bar.counters.remove(self)


### PR DESCRIPTION
Driven by the conversation in #974 

Working to add the ability to provide a callable for `remove_when_done` which is run in the background and once complete, if the return value is `True`, then the counter in question is deleted.

Example use case:

```python
from prompt_toolkit.shortcuts.progress_bar import ProgressBar
import time
import random


def remove_when_done(counter):
    if counter.total % 2:
        time.sleep(2.5)
        return True


with ProgressBar() as group:
    for label in "ABCDEFGH":
        for _ in group(range(random.randrange(5, 10)), label=label, remove_when_done=remove_when_done):
            time.sleep(.1)
```

@jonathanslenders I'm still trying to wrap my head around Python's async, I don't think I'm understanding tasks correctly so I haven't been able to get this concept to work yet. The above example generates the progress bars as expected and the background tasks appear to be created however the actual removals themselves are not occurring. I'm also getting a RuntimeError when the application attempts to finalize/cleanup:

```
RuntimeError: Task <Task pending name='Task-1' coro=<...> cb=[_run_until_complete_cb() at ...]> got Future <Task cancelling name='Task-12' coro=<ProgressBarCounter._remove_when_done_async() running at ...>> attached to a different loop
```

I've been testing with 3.8.