### PR TITLE
Set time left to 0 when done or stopped

### DIFF
--- a/prompt_toolkit/shortcuts/progress_bar/base.py
+++ b/prompt_toolkit/shortcuts/progress_bar/base.py
@@ -438,5 +438,7 @@ class ProgressBarCounter(Generic[_CounterItem]):
         """
         if self.total is None or not self.percentage:
             return None
+        elif self.done or self.stopped:
+            return datetime.timedelta(0)
         else:
             return self.time_elapsed * (100 - self.percentage) / self.percentage


### PR DESCRIPTION
From https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1029#issuecomment-568082229

When a counter is `done` or `stopped` zero the time left irrelevant of the percentage completed.