### PR TITLE
Remove unicode_literals import from examples, README and tests (not n…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,10 +109,6 @@ examples are chosen to demonstrate only one thing. Also, don't be afraid to
 look at the source code. The implementation of the ``prompt`` function could be
 a good start.
 
-Note for Python 2: all strings are expected to be unicode strings. So, either
-put a small ``u`` in front of every string or put ``from __future__ import
-unicode_literals`` at the start of the above example.
-
 Philosophy
 **********
 

--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -22,7 +22,6 @@ and returns the text. Just like ``(raw_)input``.
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import prompt
 
     text = prompt('Give me some input: ')
@@ -34,14 +33,6 @@ What we get here is a simple prompt that supports the Emacs key bindings like
 readline, but further nothing special. However,
 :func:`~prompt_toolkit.shortcuts.prompt` has a lot of configuration options.
 In the following sections, we will discover all these parameters.
-
-.. note::
-
-    `prompt_toolkit` expects unicode strings everywhere. If you are using
-    Python 2, make sure that all strings which are passed to `prompt_toolkit`
-    are unicode strings (and not bytes). Either use
-    ``from __future__ import unicode_literals`` or explicitly put a small
-    ``'u'`` in front of every string.
 
 
 The `PromptSession` object

--- a/docs/pages/getting_started.rst
+++ b/docs/pages/getting_started.rst
@@ -54,7 +54,6 @@ and returns the text. Just like ``(raw_)input``.
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import prompt
 
     text = prompt('Give me some input: ')

--- a/docs/pages/printing_text.rst
+++ b/docs/pages/printing_text.rst
@@ -26,24 +26,14 @@ The print function can be imported as follows:
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import print_formatted_text
 
     print_formatted_text('Hello world')
-
-.. note::
-
-    `prompt_toolkit` expects unicode strings everywhere. If you are using
-    Python 2, make sure that all strings which are passed to `prompt_toolkit`
-    are unicode strings (and not bytes). Either use
-    ``from __future__ import unicode_literals`` or explicitly put a small
-    ``'u'`` in front of every string.
 
 You can replace the built in ``print`` function as follows, if you want to.
 
 .. code:: python
 
-    from __future__ import unicode_literals, print_function
     from prompt_toolkit import print_formatted_text as print
 
     print('Hello world')
@@ -81,7 +71,6 @@ italic and underline: ``<b>``, ``<i>`` and ``<u>``.
 
 .. code:: python
 
-    from __future__ import unicode_literals, print_function
     from prompt_toolkit import print_formatted_text, HTML
 
     print_formatted_text(HTML('<b>This is bold</b>'))
@@ -114,7 +103,6 @@ assign a style for a custom tag.
 
 .. code:: python
 
-    from __future__ import unicode_literals, print_function
     from prompt_toolkit import print_formatted_text, HTML
     from prompt_toolkit.styles import Style
 
@@ -137,7 +125,6 @@ class takes care of that.
 
 .. code:: python
 
-    from __future__ import unicode_literals, print_function
     from prompt_toolkit import print_formatted_text, ANSI
 
     print_formatted_text(ANSI('\x1b[31mhello \x1b[32mworld'))
@@ -160,7 +147,6 @@ way of expressing formatted text.
 
 .. code:: python
 
-    from __future__ import unicode_literals, print_function
     from prompt_toolkit import print_formatted_text
     from prompt_toolkit.formatted_text import FormattedText
 
@@ -177,7 +163,6 @@ possible to use class names, and separate the styling in a style sheet.
 
 .. code:: python
 
-    from __future__ import unicode_literals, print_function
     from prompt_toolkit import print_formatted_text
     from prompt_toolkit.formatted_text import FormattedText
     from prompt_toolkit.styles import Style

--- a/docs/pages/tutorials/repl.rst
+++ b/docs/pages/tutorials/repl.rst
@@ -23,7 +23,6 @@ function as a good practise.
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import prompt
 
     def main():
@@ -55,7 +54,6 @@ respectively.
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import PromptSession
 
     def main():
@@ -92,7 +90,6 @@ wrapped into a :class:`~prompt_toolkit.lexers.PygmentsLexer`.
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import PromptSession
     from prompt_toolkit.lexers import PygmentsLexer
     from pygments.lexers.sql import SqlLexer
@@ -134,7 +131,6 @@ Like the lexer, this ``sql_completer`` instance can be passed to either the
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import PromptSession
     from prompt_toolkit.completion import WordCompleter
     from prompt_toolkit.lexers import PygmentsLexer
@@ -195,7 +191,6 @@ function.
 
 .. code:: python
 
-    from __future__ import unicode_literals
     from prompt_toolkit import PromptSession
     from prompt_toolkit.completion import WordCompleter
     from prompt_toolkit.lexers import PygmentsLexer
@@ -266,7 +261,6 @@ gives a good idea of how to get started.
 .. code:: python
 
     #!/usr/bin/env python
-    from __future__ import unicode_literals
     import sys
     import sqlite3
 

--- a/examples/dialogs/checkbox_dialog.py
+++ b/examples/dialogs/checkbox_dialog.py
@@ -2,8 +2,6 @@
 """
 Example of a checkbox-list-based dialog.
 """
-from __future__ import unicode_literals
-
 from prompt_toolkit.shortcuts import checkboxlist_dialog, message_dialog
 from prompt_toolkit.styles import Style
 

--- a/tests/test_async_generator.py
+++ b/tests/test_async_generator.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from asyncio import get_event_loop
 
 from prompt_toolkit.eventloop import generator_to_async_generator

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.buffer import Buffer

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,6 @@
 These are almost end-to-end tests. They create a Prompt, feed it with some
 input and check the result.
 """
-from __future__ import unicode_literals
-
 from functools import partial
 
 import pytest

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import re
 import shutil

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.document import Document

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.filters import Always, Condition, Filter, Never, to_filter

--- a/tests/test_formatted_text.py
+++ b/tests/test_formatted_text.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prompt_toolkit.formatted_text import (
     ANSI,
     HTML,

--- a/tests/test_inputstream.py
+++ b/tests/test_inputstream.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.input.vt100_parser import Vt100Parser

--- a/tests/test_key_binding.py
+++ b/tests/test_key_binding.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.application import Application

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.layout import InvalidLayoutError, Layout

--- a/tests/test_print_formatted_text.py
+++ b/tests/test_print_formatted_text.py
@@ -1,8 +1,6 @@
 """
 Test the `print` function.
 """
-from __future__ import print_function, unicode_literals
-
 import pytest
 
 from prompt_toolkit import print_formatted_text as pt_print

--- a/tests/test_regular_languages.py
+++ b/tests/test_regular_languages.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from prompt_toolkit.contrib.regular_languages import compile
 from prompt_toolkit.contrib.regular_languages.compiler import Match, Variables

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prompt_toolkit.styles import Attrs, Style, SwapLightAndDarkStyleTransformation
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 
 import pytest

--- a/tests/test_vt100_output.py
+++ b/tests/test_vt100_output.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prompt_toolkit.output.vt100 import _get_closest_ansi_color
 
 

--- a/tests/test_yank_nth_arg.py
+++ b/tests/test_yank_nth_arg.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from prompt_toolkit.buffer import Buffer

--- a/tools/debug_vt100_input.py
+++ b/tools/debug_vt100_input.py
@@ -3,8 +3,6 @@
 Parse vt100 input and print keys.
 For testing terminal input.
 """
-from __future__ import unicode_literals
-
 import sys
 
 from prompt_toolkit.input.vt100 import raw_mode


### PR DESCRIPTION
…eeded for Python 3).