### PR TITLE
Added always-prefer-tty attribute to create_input() and create_output().

### DIFF
--- a/prompt_toolkit/input/vt100.py
+++ b/prompt_toolkit/input/vt100.py
@@ -67,6 +67,7 @@ class Vt100Input(Input):
         if not isatty and fd not in Vt100Input._fds_not_a_terminal:
             msg = "Warning: Input is not a terminal (fd=%r).\n"
             sys.stderr.write(msg % fd)
+            sys.stderr.flush()
             Vt100Input._fds_not_a_terminal.add(fd)
 
         #

--- a/prompt_toolkit/output/defaults.py
+++ b/prompt_toolkit/output/defaults.py
@@ -15,22 +15,29 @@ __all__ = [
 ]
 
 
-def create_output(stdout: Optional[TextIO] = None) -> Output:
+def create_output(
+    stdout: Optional[TextIO] = None, always_prefer_tty: bool = True
+) -> Output:
     """
     Return an :class:`~prompt_toolkit.output.Output` instance for the command
     line.
 
     :param stdout: The stdout object
+    :param always_prefer_tty: When set, look for `sys.stderr` if `sys.stdout`
+        is not a TTY. (The prompt_toolkit render output is not meant to be
+        consumed by something other then a terminal, so this is a reasonable
+        default.)
     """
     if stdout is None:
         # By default, render to stdout. If the output is piped somewhere else,
-        # render to stderr. The prompt_toolkit render output is not meant to be
-        # consumed by something other then a terminal, so this is a reasonable
-        # default.
-        if sys.stdout.isatty():
-            stdout = sys.stdout
-        else:
-            stdout = sys.stderr
+        # render to stderr.
+        stdout = sys.stdout
+
+        if always_prefer_tty:
+            for io in [sys.stdout, sys.stderr]:
+                if io.isatty():
+                    stdout = io
+                    break
 
     # If the patch_stdout context manager has been used, then sys.stdout is
     # replaced by this proxy. For prompt_toolkit applications, we want to use

--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -451,6 +451,7 @@ class Vt100_Output(Output):
         if not stdout.isatty() and fd not in cls._fds_not_a_terminal:
             msg = "Warning: Output is not a terminal (fd=%r).\n"
             sys.stderr.write(msg % fd)
+            sys.stderr.flush()
             cls._fds_not_a_terminal.add(fd)
 
         def get_size() -> Size:


### PR DESCRIPTION
For stdout, this is enabled by default, for stdin this is not enabled anymore.
(Now that we support dumb terminals, it does also make sense to read input from
a pipe.)