### PR TITLE
set_exeption_handler improvements

### DIFF
--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -807,7 +807,9 @@ class Application(Generic[_AppResult]):
             loop = new_event_loop()
             set_event_loop(loop)
 
-        return loop.run_until_complete(self.run_async(pre_run=pre_run, set_exception_handler=set_exception_handler))
+        return loop.run_until_complete(
+            self.run_async(pre_run=pre_run, set_exception_handler=set_exception_handler)
+        )
 
     def _handle_exception(self, loop, context: Dict[str, Any]) -> None:
         """

--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -807,7 +807,7 @@ class Application(Generic[_AppResult]):
             loop = new_event_loop()
             set_event_loop(loop)
 
-        return loop.run_until_complete(self.run_async(pre_run=pre_run))
+        return loop.run_until_complete(self.run_async(pre_run=pre_run, set_exception_handler=set_exception_handler))
 
     def _handle_exception(self, loop, context: Dict[str, Any]) -> None:
         """

--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -870,6 +870,7 @@ class PromptSession(Generic[_T]):
         default: Union[str, Document] = "",
         accept_default: bool = False,
         pre_run: Optional[Callable[[], None]] = None,
+        set_exception_handler: bool = True,
     ) -> _T:
         """
         Display the prompt.
@@ -994,7 +995,7 @@ class PromptSession(Generic[_T]):
         if self._output is None and is_dumb_terminal():
             return get_event_loop().run_until_complete(self._dumb_prompt(self.message))
 
-        return self.app.run()
+        return self.app.run(set_exception_handler=set_exception_handler)
 
     async def _dumb_prompt(self, message: AnyFormattedText = "") -> _T:
         """
@@ -1088,6 +1089,7 @@ class PromptSession(Generic[_T]):
         default: Union[str, Document] = "",
         accept_default: bool = False,
         pre_run: Optional[Callable[[], None]] = None,
+        set_exception_handler: bool = True,
     ) -> _T:
 
         if message is not None:
@@ -1172,7 +1174,7 @@ class PromptSession(Generic[_T]):
         if self._output is None and is_dumb_terminal():
             return await self._dumb_prompt(self.message)
 
-        return await self.app.run_async()
+        return await self.app.run_async(set_exception_handler=set_exception_handler)
 
     def _add_pre_run_callables(
         self, pre_run: Optional[Callable[[], None]], accept_default: bool


### PR DESCRIPTION
This is just a couple minor tweaks.
- `Application.run` was taking a `set_exception_handler` parameter but never using it, so I just added the code to forward it to the `Application.run_async` call. 
- Added `set_exception_handler` parameters to `PromptSession`.  I've found it's useful even in the context of a shortcut class like `PromptSession` to replace the application's default exception handler if you, for example, want to do something like exit the application on exception.