### PR TITLE
Bugfix in invalidate code: PromptSession was invalidating the UI cont…

### DIFF
--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -527,7 +527,7 @@ class Application(Generic[_AppResult]):
         Start a while/true loop in the background for automatic invalidation of
         the UI.
         """
-        if self.refresh_interval is not None:
+        if self.refresh_interval not in (None, 0):
             refresh_interval = self.refresh_interval
 
             async def auto_refresh() -> None:


### PR DESCRIPTION
…inuously.

When the refresh interval is 0, which is the default in `PromptSession`, don't
run a refresh loop. This significantly reduces CPU usage when idle.