### PR TITLE
Drop last use of six

### DIFF
--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -4,8 +4,6 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 
-from six import text_type
-
 from prompt_toolkit.completion import (
     CompleteEvent,
     FuzzyWordCompleter,
@@ -82,7 +80,7 @@ def test_pathcompleter_completes_files_in_absolute_directory():
 
     completer = PathCompleter()
     # force unicode
-    doc_text = text_type(test_dir)
+    doc_text = str(test_dir)
     doc = Document(doc_text, len(doc_text))
     event = CompleteEvent()
     completions = list(completer.get_completions(doc, event))


### PR DESCRIPTION
This appears to be the only remaining reference to `six`, which can probably be dropped completely as a test requirement now that python 2 compat is no longer required.