### PR TITLE
Ensure rprompt aligns with input.

### DIFF
--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -662,7 +662,7 @@ class PromptSession(Generic[_T]):
                         # The right prompt.
                         Float(
                             right=0,
-                            top=0,
+                            bottom=0,
                             hide_when_covering_content=True,
                             content=_RPrompt(lambda: self.rprompt),
                         ),


### PR DESCRIPTION
Align the rprompt with the input line in the case of a multi-line prompt text. Since this is a change on the float, we can't simply style the rprompt to get the desired intent.