### PR TITLE
Cancel CPR futures before dropping them

### DIFF
--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -554,6 +554,8 @@ class Renderer:
             await sleep(timeout)
 
             # Got timeout, erase queue.
+            for response_f in cpr_futures:
+                response_f.cancel()
             self._waiting_for_cpr_futures = deque()
 
         coroutines = [


### PR DESCRIPTION
If the futures are not cancelled before being dropped, you can run into asyncio exceptions about a destroyed task that is pending.

In a program I'm running that calls `prompt` inside a `patch_stdout` context, printing a couple dozen `logging` messages causes these CPR futures to time out. Wthout this change, I get an exception context that looks like this:
```
Exception {'message': 'Task was destroyed but it is pending!', 'task': <Task pending coro=<Renderer.wait_for_cpr_responses.<locals>.wait_for_responses() done, defined at /home/mark/repos/toolkit/prompt_toolkit/renderer.py:549> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f0e2da64ee8>()]>>}
```
With this change, those errors are gone.