### PR TITLE
Prompt in toolbar

### DIFF
--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -685,6 +685,10 @@ after completion.
 
     answer = prompt(": ", prompt_in_toolbar=True)
 
+This sort of prompt does not work well with readline-like completers due to the
+floating nature of the toolbar. If you are implementing completers for a
+toolbar-based prompt, it is recommended to use one of the default floating
+completers.
 
 Vi input mode
 -------------

--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -668,6 +668,23 @@ directly to the ``rprompt`` argument of the
 :func:`~prompt_toolkit.shortcuts.prompt` function. It does not have to be a
 callable.
 
+Asking for input from a toolbar
+-------------------------------
+
+The :func:`~prompt_toolkit.shortcuts.prompt` function as out of the box support
+to place the input prompt in a toolbar at the bottom of the screen similar to
+how the ``tmux`` ":" shortcut prompts by default in the toolbar.
+
+Setting the `prompt_in_toolbar` argument to ``True`` will enable this feature.
+This option also automatically turns on ``erase_when_done`` to clear the toolbar
+after completion.
+
+.. code:: python
+    
+    from prompt_toolkit import prompt
+
+    answer = prompt(": ", prompt_in_toolbar=True)
+
 
 Vi input mode
 -------------

--- a/examples/prompts/toolbar-prompt.py
+++ b/examples/prompts/toolbar-prompt.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+""" 
+Prompt for user input as a toolbar which disappears after submission.
+"""
+from prompt_toolkit import prompt
+
+if __name__ == "__main__":
+    answer = prompt(message="prompt$ ", prompt_in_toolbar=True)
+    print(f"You said: {answer}")

--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -3,7 +3,7 @@ Container for the layout.
 (Containers can contain other containers or user interface controls.)
 """
 from abc import ABCMeta, abstractmethod
-from enum import Enum
+from enum import Enum, auto
 from functools import partial
 from typing import (
     TYPE_CHECKING,
@@ -737,6 +737,19 @@ class VSplit(_Split):
             )
 
 
+class Relative(Enum):
+    """ Relative positioning constants used with xcursor and ycursor """
+
+    # Not relative to cursor
+    NONE = auto()
+    # Position at the cursor
+    OVER = auto()
+    # Position before the cursor
+    BEFORE = auto()
+    # Position after the cursor
+    AFTER = auto()
+
+
 class FloatContainer(Container):
     """
     Container which can contain another container for the background, as well
@@ -891,7 +904,7 @@ class FloatContainer(Container):
             xpos = write_position.width - fl.right - fl_width
             width = fl_width
         # Near x position of cursor.
-        elif fl.xcursor:
+        elif fl.xcursor is Relative.AFTER:
             if fl_width is None:
                 width = fl.content.preferred_width(write_position.width).preferred
                 width = min(write_position.width, width)
@@ -901,6 +914,17 @@ class FloatContainer(Container):
             xpos = cursor_position.x
             if xpos + width > write_position.width:
                 xpos = max(0, write_position.width - width)
+        # Position before the cursor
+        elif fl.xcursor is Relative.BEFORE:
+            if fl_width is None:
+                width = fl.content.preferred_width(write_position.width).preferred
+                width = min(write_position.width, width)
+            else:
+                width = fl_width
+
+            xpos = max(0, cursor_position.x - width)
+            # Ensure we aren't wider than the space we have
+            width = min(width, cursor_position.x)
         # Only width given -> center horizontally.
         elif fl_width:
             xpos = int((write_position.width - fl_width) / 2)
@@ -932,7 +956,7 @@ class FloatContainer(Container):
             ypos = write_position.height - fl_height - fl.bottom
             height = fl_height
         # Near cursor.
-        elif fl.ycursor:
+        elif fl.ycursor == Relative.AFTER:
             ypos = cursor_position.y + (0 if fl.allow_cover_cursor else 1)
 
             if fl_height is None:
@@ -953,7 +977,18 @@ class FloatContainer(Container):
                     # Otherwise, fit the float above the cursor.
                     height = min(height, cursor_position.y)
                     ypos = cursor_position.y - height
+        elif fl.ycursor == Relative.BEFORE:
+            if fl_height is None:
+                height = fl.content.preferred_height(
+                    width, write_position.height
+                ).preferred
+            else:
+                height = fl_height
 
+            ypos = max(0, cursor_position.y - height) + (
+                1 if fl.allow_cover_cursor else 0
+            )
+            height = min(height, cursor_position.y)
         # Only height given -> center vertically.
         elif fl_height:
             ypos = int((write_position.height - fl_height) / 2)
@@ -1057,8 +1092,8 @@ class Float:
         left: Optional[int] = None,
         width: Optional[Union[int, Callable[[], int]]] = None,
         height: Optional[Union[int, Callable[[], int]]] = None,
-        xcursor: bool = False,
-        ycursor: bool = False,
+        xcursor: Union[bool, Relative] = Relative.NONE,
+        ycursor: Union[bool, Relative] = Relative.NONE,
         attach_to_window: Optional[AnyContainer] = None,
         hide_when_covering_content: bool = False,
         allow_cover_cursor: bool = False,
@@ -1067,6 +1102,16 @@ class Float:
     ):
 
         assert z_index >= 1
+
+        if isinstance(xcursor, bool) and xcursor:
+            xcursor = Relative.AFTER
+        elif isinstance(xcursor, bool):
+            xcursor = Relative.NONE
+
+        if isinstance(ycursor, bool) and ycursor:
+            ycursor = Relative.AFTER
+        elif isinstance(ycursor, bool):
+            ycursor = Relative.NONE
 
         self.left = left
         self.right = right

--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -318,6 +318,8 @@ class PromptSession(Generic[_T]):
         every so many seconds.
     :param input: `Input` object. (Note that the preferred way to change the
         input/output is by creating an `AppSession`.)
+    :param prompt_in_toolbar: `bool`. Whether to display the prompt in a
+        toolbar at the bottom of the screen (automatically enables erase_when_done).
     :param output: `Output` object.
     """
 


### PR DESCRIPTION
This merge would add the following features:

* Primarily, add the ability to specify the `prompt_in_toolbar` argument to `PrompSession` and `prompt` which places the prompt in a toolbar at the bottom of the screen.
* As an added bonus, in order to account for completions, I needed to add better cursor-relative position for Floats. A new Enum named Relative is used for xcursor and ycursor arguments which can be Relative.NONE, Relative.BEFORE or Relative.AFTER.

When setting `prompt_in_toolbar` to true, the `erase_when_done` parameter is also automatically enabled, as this makes sense if the prompt is in a toolbar. Also, if this parameter is used, `_get_default_buffer_control_height` is no longer used for the buffer control height directly. Instead, it adjusts the padding object above the prompt. The new relative position is used to position the completion menu before the prompt (vertically) and the changed padding allows the completion padding to pad above vice below to match where the menu is display.

I added comments near changed code, and also added a section to the documentation on "asking for inputs" and the docstring for PromptSession. I used Python Black for formatting, so the code is pre-formatted, although I didn't see any coding standard specifics in the repo to go by.

If you have any questions or comments, let me know. Thanks!