### PR TITLE
Better support for remote terminals

### DIFF
--- a/examples/ssh/asyncssh-server.py
+++ b/examples/ssh/asyncssh-server.py
@@ -9,7 +9,7 @@ import asyncssh
 from pygments.lexers.html import HtmlLexer
 
 from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit.contrib.ssh import PromptToolkitSSHServer
+from prompt_toolkit.contrib.ssh import PromptToolkitSSHServer, PromptToolkitSSHSession
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.shortcuts import ProgressBar, print_formatted_text
 from prompt_toolkit.shortcuts.dialogs import input_dialog, yes_no_dialog
@@ -54,7 +54,7 @@ animal_completer = WordCompleter(
 )
 
 
-async def interact() -> None:
+async def interact(ssh_session: PromptToolkitSSHSession) -> None:
     """
     The application interaction.
 

--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -366,10 +366,10 @@ class Application(Generic[_AppResult]):
         depth = self._color_depth
 
         if callable(depth):
-            return depth() or ColorDepth.default()
+            return depth() or self.output.get_default_color_depth()
 
         if depth is None:
-            return ColorDepth.default()
+            return self.output.get_default_color_depth()
 
         return depth
 

--- a/prompt_toolkit/contrib/ssh/__init__.py
+++ b/prompt_toolkit/contrib/ssh/__init__.py
@@ -1,6 +1,6 @@
-from .server import PromptToolkitSession, PromptToolkitSSHServer
+from .server import PromptToolkitSSHServer, PromptToolkitSSHSession
 
 __all__ = [
-    "PromptToolkitSession",
+    "PromptToolkitSSHSession",
     "PromptToolkitSSHServer",
 ]

--- a/prompt_toolkit/contrib/telnet/server.py
+++ b/prompt_toolkit/contrib/telnet/server.py
@@ -81,6 +81,7 @@ class _ConnectionStdout:
         self._buffer: List[bytes] = []
 
     def write(self, data: str) -> None:
+        data = data.replace("\n", "\r\n")
         self._buffer.append(data.encode(self._encoding, errors=self._errors))
         self.flush()
 

--- a/prompt_toolkit/contrib/telnet/server.py
+++ b/prompt_toolkit/contrib/telnet/server.py
@@ -11,7 +11,7 @@ from prompt_toolkit.application.current import create_app_session, get_app
 from prompt_toolkit.application.run_in_terminal import run_in_terminal
 from prompt_toolkit.data_structures import Size
 from prompt_toolkit.formatted_text import AnyFormattedText, to_formatted_text
-from prompt_toolkit.input.posix_pipe import PosixPipeInput
+from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output.vt100 import Vt100_Output
 from prompt_toolkit.renderer import print_formatted_text as print_formatted_text
 from prompt_toolkit.styles import BaseStyle, DummyStyle
@@ -26,7 +26,9 @@ from .protocol import (
     NAWS,
     SB,
     SE,
+    SEND,
     SUPPRESS_GO_AHEAD,
+    TTYPE,
     WILL,
     TelnetProtocolParser,
 )
@@ -58,6 +60,12 @@ def _initialize_telnet(connection: socket.socket) -> None:
 
     # Negotiate window size
     connection.send(IAC + DO + NAWS)
+
+    # Negotiate terminal type
+    connection.send(IAC + DO + TTYPE)
+
+    # Negotiate terminal type
+    connection.send(IAC + SB + TTYPE + SEND + IAC + SE)
 
 
 class _ConnectionStdout:
@@ -115,6 +123,8 @@ class TelnetConnection:
         self.encoding = encoding
         self.style = style
         self._closed = False
+        self._ready = asyncio.Event()
+        self.vt100_output = None
 
         # Create "Output" object.
         self.size = Size(rows=40, columns=79)
@@ -123,14 +133,13 @@ class TelnetConnection:
         _initialize_telnet(conn)
 
         # Create input.
-        self.vt100_input = PosixPipeInput()
+        self.vt100_input = create_pipe_input()
 
         # Create output.
         def get_size() -> Size:
             return self.size
 
         self.stdout = cast(TextIO, _ConnectionStdout(conn, encoding=encoding))
-        self.vt100_output = Vt100_Output(self.stdout, get_size, write_binary=False)
 
         def data_received(data: bytes) -> None:
             """ TelnetProtocolParser 'data_received' callback """
@@ -139,9 +148,17 @@ class TelnetConnection:
         def size_received(rows: int, columns: int) -> None:
             """ TelnetProtocolParser 'size_received' callback """
             self.size = Size(rows=rows, columns=columns)
-            get_app()._on_resize()
+            if self.vt100_output is not None:
+                get_app()._on_resize()
 
-        self.parser = TelnetProtocolParser(data_received, size_received)
+        def ttype_received(ttype: str) -> None:
+            """ TelnetProtocolParser 'ttype_received' callback """
+            self.vt100_output = Vt100_Output(
+                self.stdout, get_size, term=ttype, write_binary=False
+            )
+            self._ready.set()
+
+        self.parser = TelnetProtocolParser(data_received, size_received, ttype_received)
         self.context: Optional[contextvars.Context] = None
 
     async def run_application(self) -> None:
@@ -158,25 +175,24 @@ class TelnetConnection:
                 logger.info("Connection closed by client. %r %r" % self.addr)
                 self.close()
 
-        async def run() -> None:
-            # Add reader.
-            loop = get_event_loop()
-            loop.add_reader(self.conn, handle_incoming_data)
+        # Add reader.
+        loop = get_event_loop()
+        loop.add_reader(self.conn, handle_incoming_data)
 
-            try:
+        try:
+            # Wait for v100_output to be properly instantiated
+            await self._ready.wait()
+            with create_app_session(input=self.vt100_input, output=self.vt100_output):
+                self.context = contextvars.copy_context()
                 await self.interact(self)
-            except Exception as e:
-                print("Got %s" % type(e).__name__, e)
-                import traceback
+        except Exception as e:
+            print("Got %s" % type(e).__name__, e)
+            import traceback
 
-                traceback.print_exc()
-                raise
-            finally:
-                self.close()
-
-        with create_app_session(input=self.vt100_input, output=self.vt100_output):
-            self.context = contextvars.copy_context()
-            await run()
+            traceback.print_exc()
+            raise
+        finally:
+            self.close()
 
     def feed(self, data: bytes) -> None:
         """
@@ -199,6 +215,8 @@ class TelnetConnection:
         """
         Send text to the client.
         """
+        if self.vt100_output is None:
+            return
         formatted_text = to_formatted_text(formatted_text)
         print_formatted_text(
             self.vt100_output, formatted_text, self.style or DummyStyle()
@@ -224,6 +242,8 @@ class TelnetConnection:
         """
         Erase the screen and move the cursor to the top.
         """
+        if self.vt100_output is None:
+            return
         self.vt100_output.erase_screen()
         self.vt100_output.cursor_goto(0, 0)
         self.vt100_output.flush()

--- a/prompt_toolkit/contrib/telnet/server.py
+++ b/prompt_toolkit/contrib/telnet/server.py
@@ -62,9 +62,12 @@ def _initialize_telnet(connection: socket.socket) -> None:
     connection.send(IAC + DO + NAWS)
 
     # Negotiate terminal type
+    # Assume the client will accept the negociation with `IAC +  WILL + TTYPE`
     connection.send(IAC + DO + TTYPE)
 
-    # Negotiate terminal type
+    # We can then select the first terminal type supported by the client,
+    # which is generally the best type the client supports
+    # The client should reply with a `IAC + SB  + TTYPE + IS + ttype + IAC + SE`
     connection.send(IAC + SB + TTYPE + SEND + IAC + SE)
 
 

--- a/prompt_toolkit/input/base.py
+++ b/prompt_toolkit/input/base.py
@@ -95,6 +95,20 @@ class Input(metaclass=ABCMeta):
         pass
 
 
+class PipeInput(Input):
+    """
+    Abstraction for pipe input.
+    """
+
+    @abstractmethod
+    def send_bytes(self, data: bytes) -> None:
+        """Feed byte string into the pipe"""
+
+    @abstractmethod
+    def send_text(self, data: str) -> None:
+        """Feed a text string into the pipe"""
+
+
 class DummyInput(Input):
     """
     Input for use in a `DummyApplication`

--- a/prompt_toolkit/input/defaults.py
+++ b/prompt_toolkit/input/defaults.py
@@ -43,7 +43,7 @@ def create_input(
         return Vt100Input(stdin)
 
 
-def create_pipe_input() -> Input:
+def create_pipe_input(responds_to_cpr: bool = True) -> Input:
     """
     Create an input pipe.
     This is mostly useful for unit testing.
@@ -51,8 +51,8 @@ def create_pipe_input() -> Input:
     if is_windows():
         from .win32_pipe import Win32PipeInput
 
-        return Win32PipeInput()
+        return Win32PipeInput(responds_to_cpr=responds_to_cpr)
     else:
         from .posix_pipe import PosixPipeInput
 
-        return PosixPipeInput()
+        return PosixPipeInput(responds_to_cpr=responds_to_cpr)

--- a/prompt_toolkit/input/defaults.py
+++ b/prompt_toolkit/input/defaults.py
@@ -3,7 +3,7 @@ from typing import Optional, TextIO
 
 from prompt_toolkit.utils import is_windows
 
-from .base import Input
+from .base import Input, PipeInput
 
 __all__ = [
     "create_input",
@@ -43,7 +43,7 @@ def create_input(
         return Vt100Input(stdin)
 
 
-def create_pipe_input(responds_to_cpr: bool = True) -> Input:
+def create_pipe_input(responds_to_cpr: bool = True) -> PipeInput:
     """
     Create an input pipe.
     This is mostly useful for unit testing.

--- a/prompt_toolkit/input/posix_pipe.py
+++ b/prompt_toolkit/input/posix_pipe.py
@@ -23,7 +23,8 @@ class PosixPipeInput(Vt100Input):
 
     _id = 0
 
-    def __init__(self, text: str = "") -> None:
+    def __init__(self, text: str = "", responds_to_cpr: bool = True) -> None:
+        self._responds_to_cpr = True
         self._r, self._w = os.pipe()
 
         class Stdin:
@@ -44,7 +45,7 @@ class PosixPipeInput(Vt100Input):
 
     @property
     def responds_to_cpr(self) -> bool:
-        return False
+        return self._responds_to_cpr
 
     def send_bytes(self, data: bytes) -> None:
         os.write(self._w, data)

--- a/prompt_toolkit/input/posix_pipe.py
+++ b/prompt_toolkit/input/posix_pipe.py
@@ -2,6 +2,7 @@ import os
 from typing import ContextManager, TextIO, cast
 
 from ..utils import DummyContext
+from .base import PipeInput
 from .vt100 import Vt100Input
 
 __all__ = [
@@ -9,7 +10,7 @@ __all__ = [
 ]
 
 
-class PosixPipeInput(Vt100Input):
+class PosixPipeInput(Vt100Input, PipeInput):
     """
     Input that is send through a pipe.
     This is useful if we want to send the input programmatically into the

--- a/prompt_toolkit/input/win32_pipe.py
+++ b/prompt_toolkit/input/win32_pipe.py
@@ -5,13 +5,14 @@ from prompt_toolkit.eventloop.win32 import create_win32_event
 
 from ..key_binding import KeyPress
 from ..utils import DummyContext
+from .base import PipeInput
 from .vt100_parser import Vt100Parser
 from .win32 import _Win32InputBase, attach_win32_input, detach_win32_input
 
 __all__ = ["Win32PipeInput"]
 
 
-class Win32PipeInput(_Win32InputBase):
+class Win32PipeInput(_Win32InputBase, PipeInput):
     """
     This is an input pipe that works on Windows.
     Text or bytes can be feed into the pipe, and key strokes can be read from

--- a/prompt_toolkit/input/win32_pipe.py
+++ b/prompt_toolkit/input/win32_pipe.py
@@ -29,7 +29,7 @@ class Win32PipeInput(_Win32InputBase):
 
     _id = 0
 
-    def __init__(self) -> None:
+    def __init__(self, responds_to_cpr: bool = True) -> None:
         super().__init__()
         # Event (handle) for registering this input in the event loop.
         # This event is set when there is data available to read from the pipe.
@@ -39,6 +39,7 @@ class Win32PipeInput(_Win32InputBase):
         self._event = create_win32_event()
 
         self._closed = False
+        self._responds_to_cpr = responds_to_cpr
 
         # Parser for incoming keys.
         self._buffer: List[KeyPress] = []  # Buffer to collect the Key objects.
@@ -105,7 +106,7 @@ class Win32PipeInput(_Win32InputBase):
 
     @property
     def responds_to_cpr(self) -> bool:
-        return False
+        return self._responds_to_cpr
 
     def send_bytes(self, data: bytes) -> None:
         " Send bytes to the input. "

--- a/prompt_toolkit/output/base.py
+++ b/prompt_toolkit/output/base.py
@@ -163,6 +163,10 @@ class Output(metaclass=ABCMeta):
         " For Windows only. "
         raise NotImplementedError
 
+    @abstractmethod
+    def get_default_color_depth(self) -> ColorDepth:
+        " Get default color depth for this output. "
+
 
 class DummyOutput(Output):
     """
@@ -265,3 +269,6 @@ class DummyOutput(Output):
 
     def get_rows_below_cursor_position(self) -> int:
         return 40
+
+    def get_default_color_depth(self) -> ColorDepth:
+        return ColorDepth.DEPTH_1_BIT

--- a/prompt_toolkit/output/color_depth.py
+++ b/prompt_toolkit/output/color_depth.py
@@ -35,7 +35,7 @@ class ColorDepth(str, Enum):
     TRUE_COLOR = DEPTH_24_BIT
 
     @classmethod
-    def default(cls, term: Optional[str] = None) -> "ColorDepth":
+    def local_default(cls, term: Optional[str] = None) -> "ColorDepth":
         """
         Return the default color depth, according to the $TERM value.
 
@@ -50,7 +50,28 @@ class ColorDepth(str, Enum):
         """
         # Take `TERM` value from environment variable if nothing was passed.
         if term is None:
-            term = os.environ.get("TERM", "")
+            term = os.environ.get("TERM")
+
+        if is_dumb_terminal(term):
+            return cls.DEPTH_1_BIT
+
+        # Check the `PROMPT_TOOLKIT_COLOR_DEPTH` environment variable.
+        all_values = [i.value for i in ColorDepth]
+        if os.environ.get("PROMPT_TOOLKIT_COLOR_DEPTH") in all_values:
+            return cls(os.environ["PROMPT_TOOLKIT_COLOR_DEPTH"])
+
+        return cls.windows_default() if is_windows() else cls.vt100_default(term)
+
+    @classmethod
+    def vt100_default(cls, term: Optional[str] = None) -> "ColorDepth":
+        """Return the default color depth for a vt100 terminal, according to the term
+        value.
+
+        Contrary to `local_default`, this method doesn't take the local system into
+        account.
+        """
+        if term is None:
+            return cls.DEFAULT
 
         if is_dumb_terminal(term):
             return cls.DEPTH_1_BIT
@@ -58,17 +79,17 @@ class ColorDepth(str, Enum):
         if term in ("linux", "eterm-color"):
             return cls.DEPTH_4_BIT
 
+        return cls.DEFAULT
+
+    @classmethod
+    def windows_default(cls) -> "ColorDepth":
+        """Return the default color depth for a windows terminal.
+
+        Contrary to `local_default`, this method doesn't take the local system into
+        account.
+        """
         # For now, always use 4 bit color on Windows 10 by default, even when
         # vt100 escape sequences with ENABLE_VIRTUAL_TERMINAL_PROCESSING are
         # supported. We don't have a reliable way yet to know whether our
         # console supports true color or only 4-bit.
-        if is_windows() and "PROMPT_TOOLKIT_COLOR_DEPTH" not in os.environ:
-            return cls.DEPTH_4_BIT
-
-        # Check the `PROMPT_TOOLKIT_COLOR_DEPTH` environment variable.
-        all_values = [i.value for i in ColorDepth]
-
-        if os.environ.get("PROMPT_TOOLKIT_COLOR_DEPTH") in all_values:
-            return cls(os.environ["PROMPT_TOOLKIT_COLOR_DEPTH"])
-
-        return cls.DEPTH_8_BIT
+        return cls.DEPTH_4_BIT

--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -426,7 +426,7 @@ class Vt100_Output(Output):
         self.stdout = stdout
         self.write_binary = write_binary
         self._get_size = get_size
-        self.term = term or "xterm"
+        self.term = term
 
         # Cache for escape codes.
         self._escape_code_caches: Dict[ColorDepth, _EscapeCodeCache] = {
@@ -683,3 +683,6 @@ class Vt100_Output(Output):
         " Sound bell. "
         self.write_raw("\a")
         self.flush()
+
+    def get_default_color_depth(self) -> ColorDepth:
+        return ColorDepth.vt100_default(self.term)

--- a/prompt_toolkit/output/win32.py
+++ b/prompt_toolkit/output/win32.py
@@ -479,6 +479,9 @@ class Win32Output(Output):
         RDW_INVALIDATE = 0x0001
         windll.user32.RedrawWindow(handle, None, None, c_uint(RDW_INVALIDATE))
 
+    def get_default_color_depth(self) -> ColorDepth:
+        return ColorDepth.windows_default()
+
 
 class FOREGROUND_COLOR:
     BLACK = 0x0000

--- a/prompt_toolkit/output/windows10.py
+++ b/prompt_toolkit/output/windows10.py
@@ -60,6 +60,7 @@ class Windows10_Output:
             "get_win32_screen_buffer_info",
             "enable_bracketed_paste",
             "disable_bracketed_paste",
+            "get_default_color_depth",
         ):
             return getattr(self.win32_output, name)
         else:

--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -21,7 +21,6 @@ from prompt_toolkit.styles import (
     DummyStyleTransformation,
     StyleTransformation,
 )
-from prompt_toolkit.utils import is_windows
 
 if TYPE_CHECKING:
     from prompt_toolkit.application import Application
@@ -396,7 +395,8 @@ class Renderer:
 
         # In case of Windows, also make sure to scroll to the current cursor
         # position. (Only when rendering the first time.)
-        if is_windows() and _scroll:
+        # It does nothing for vt100 terminals.
+        if _scroll:
             self.output.scroll_buffer_to_prompt()
 
         # Quit alternate screen.
@@ -432,9 +432,13 @@ class Renderer:
         is known. (It's often nicer to draw bottom toolbars only if the height
         is known, in order to avoid flickering when the CPR response arrives.)
         """
-        return (
-            self.full_screen or self._min_available_height > 0 or is_windows()
-        )  # On Windows, we don't have to wait for a CPR.
+        if self.full_screen or self._min_available_height > 0:
+            return True
+        try:
+            self._min_available_height = self.output.get_rows_below_cursor_position()
+            return True
+        except NotImplementedError:
+            return False
 
     @property
     def rows_above_layout(self) -> int:
@@ -468,42 +472,48 @@ class Renderer:
         # In full-screen mode, always use the total height as min-available-height.
         if self.full_screen:
             self._min_available_height = self.output.get_size().rows
+            return
 
         # For Win32, we have an API call to get the number of rows below the
         # cursor.
-        elif is_windows():
+        try:
             self._min_available_height = self.output.get_rows_below_cursor_position()
+            return
+        except NotImplementedError:
+            pass
 
         # Use CPR.
-        else:
-            if self.cpr_support == CPR_Support.NOT_SUPPORTED:
-                return
+        if self.cpr_support == CPR_Support.NOT_SUPPORTED:
+            return
 
-            def do_cpr() -> None:
-                # Asks for a cursor position report (CPR).
-                self._waiting_for_cpr_futures.append(Future())
-                self.output.ask_for_cpr()
+        def do_cpr() -> None:
+            # Asks for a cursor position report (CPR).
+            self._waiting_for_cpr_futures.append(Future())
+            self.output.ask_for_cpr()
 
-            if self.cpr_support == CPR_Support.SUPPORTED:
-                do_cpr()
+        if self.cpr_support == CPR_Support.SUPPORTED:
+            do_cpr()
+            return
 
-            # If we don't know whether CPR is supported, only do a request if
-            # none is pending, and test it, using a timer.
-            elif self.cpr_support == CPR_Support.UNKNOWN and not self.waiting_for_cpr:
-                do_cpr()
+        # If we don't know whether CPR is supported, only do a request if
+        # none is pending, and test it, using a timer.
+        if self.waiting_for_cpr:
+            return
 
-                async def timer() -> None:
-                    await sleep(self.CPR_TIMEOUT)
+        do_cpr()
 
-                    # Not set in the meantime -> not supported.
-                    if self.cpr_support == CPR_Support.UNKNOWN:
-                        self.cpr_support = CPR_Support.NOT_SUPPORTED
+        async def timer() -> None:
+            await sleep(self.CPR_TIMEOUT)
 
-                        if self.cpr_not_supported_callback:
-                            # Make sure to call this callback in the main thread.
-                            self.cpr_not_supported_callback()
+            # Not set in the meantime -> not supported.
+            if self.cpr_support == CPR_Support.UNKNOWN:
+                self.cpr_support = CPR_Support.NOT_SUPPORTED
 
-                get_app().create_background_task(timer())
+                if self.cpr_not_supported_callback:
+                    # Make sure to call this callback in the main thread.
+                    self.cpr_not_supported_callback()
+
+        get_app().create_background_task(timer())
 
     def report_absolute_cursor_row(self, row: int) -> None:
         """

--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -742,7 +742,7 @@ def print_formatted_text(
     """
     fragments = to_formatted_text(formatted_text)
     style_transformation = style_transformation or DummyStyleTransformation()
-    color_depth = color_depth or ColorDepth.default()
+    color_depth = color_depth or output.get_default_color_depth()
 
     # Reset first.
     output.reset_attributes()

--- a/prompt_toolkit/shortcuts/utils.py
+++ b/prompt_toolkit/shortcuts/utils.py
@@ -114,7 +114,7 @@ def print_formatted_text(
     assert isinstance(output, Output)
 
     # Get color depth.
-    color_depth = color_depth or ColorDepth.default()
+    color_depth = color_depth or output.get_default_color_depth()
 
     # Merges values.
     def to_text(val: Any) -> StyleAndTextTuples:


### PR DESCRIPTION
(Fix https://github.com/prompt-toolkit/python-prompt-toolkit/issues/876)

### Context

I'm trying to serve a ptpython console using both telnet and ssh:
https://gist.github.com/vxgmichel/7685685b3e5ead04ada4a3ba75a48eef

With the recent efforts to port prompt-toolkit to asyncio, it feels like the project is really close to have a nice and clean separation between the terminal on one side (thanks to `create_app_session`) and the application on the other side. Notice how simple the gist is, especially compared to [the one I wrote last year](https://gist.github.com/vxgmichel/f99c372f05dafb16ab24960d985ba61a) for prompt-toolkit 2.

However, I ran into a few problems when trying to run this example on linux and windows (with telnet and ssh clients running on both linux and windows). Some were related to ptpython itself and I'll make a separate PR on the ptpython repo.

### Issues

On the prompt-toolkit side, I noticed the following issues:

- Pipe input objects do not respond to CPR even though the client most probably does (see #876). I made `responds_to_cpr` configurable and defaulting to `True` for pipe input objects since it is assumed that they support `VT100`.

- Some code, mostly in `renderer.py`, uses `is_windows()` to perform some specific operations for local windows terminal. The problem is that one might use windows to serve an application to remote clients. The commit cb901ba implements `output.is_windows()` for this purpose. It also has to tweak a bit how the default color depth is chosen, for the same reasons.

- The telnet and ssh servers were not compatible with windows, but more importantly they did not provide the client terminal type to the prompt-toolkit session. Both protocol support having the client report its terminal type, so getting and setting this type as `output.term` opens the way to better remote terminal support (typically using the right color depth for the client terminal).

- The ssh server replaces LF by CRLF before writing to the client stream, but the telnet client does not. I fixed it in the telnet server for consistency even though I'm a bit puzzled by the CRLF handling in general. From what I can tell, `print_formatted_text` [does perform this replacing already](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/a49c486fa5ae6ad5a38ff3c1050f9c9609acac1d/prompt_toolkit/renderer.py#L769), but it also happens that the `output.write()` method is used directly in some case. I could only find [one occurrence](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/a49c486fa5ae6ad5a38ff3c1050f9c9609acac1d/prompt_toolkit/shortcuts/prompt.py#L1037)) in `prompt-toolkit` and it does use CRLF. However, there is plenty of write calls in the ptpython REPL that uses LF instead (e.g [when rendering an exception](https://github.com/prompt-toolkit/ptpython/blob/89017ba158ed1d95319233fa5aedf3931c3b8b77/ptpython/repl.py#L241)).

### Proof of concept

This PR is a proof of concept and is probably not ready to merge as it is, especially since it changes some part of the prompt-toolkit API (e.g `ColorDepth.default`).
