### PR TITLE
Removed "true_color" documentation

### DIFF
--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -225,9 +225,7 @@ names to refer to the style.
 The `message` can be any kind of formatted text, as discussed :ref:`here
 <formatted_text>`. It can also be a callable that returns some formatted text.
 
-By default, colors are taking from the 256 color palette. If you want to have
-24bit true color, this is possible by adding the ``true_color=True`` option to
-the :func:`~prompt_toolkit.shortcuts.prompt.prompt` function.
+By default, colors are taking from the 256 color palette.
 
 .. code:: python
 


### PR DESCRIPTION
The "true_color" parameter for a prompt session does not exist, and I propsed it shoud be removed from the docs, until it is possibly implemented.