### PR TITLE
Introduce vi_state.InputMode.REPLACE_SINGLE

### DIFF
--- a/prompt_toolkit/filters/app.py
+++ b/prompt_toolkit/filters/app.py
@@ -287,6 +287,25 @@ def vi_replace_mode() -> bool:
 
 
 @Condition
+def vi_replace_single_mode() -> bool:
+    from prompt_toolkit.key_binding.vi_state import InputMode
+
+    app = get_app()
+
+    if (
+        app.editing_mode != EditingMode.VI
+        or app.vi_state.operator_func
+        or app.vi_state.waiting_for_digraph
+        or app.current_buffer.selection_state
+        or app.vi_state.temporary_navigation_mode
+        or app.current_buffer.read_only()
+    ):
+        return False
+
+    return app.vi_state.input_mode == InputMode.REPLACE_SINGLE
+
+
+@Condition
 def vi_selection_mode() -> bool:
     app = get_app()
     if app.editing_mode != EditingMode.VI:

--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -27,6 +27,7 @@ from prompt_toolkit.filters.app import (
     vi_navigation_mode,
     vi_recording_macro,
     vi_replace_mode,
+    vi_replace_single_mode,
     vi_search_direction_reversed,
     vi_selection_mode,
     vi_waiting_for_text_object_mode,
@@ -797,13 +798,12 @@ def load_vi_bindings() -> KeyBindingsBase:
                     data, count=event.arg, paste_mode=PasteMode.VI_BEFORE
                 )
 
-    @handle("r", Keys.Any, filter=vi_navigation_mode)
+    @handle("r", filter=vi_navigation_mode)
     def _replace(event: E) -> None:
         """
-        Replace single character under cursor
+        Go to 'replace-single'-mode.
         """
-        event.current_buffer.insert_text(event.data * event.arg, overwrite=True)
-        event.current_buffer.cursor_position -= 1
+        event.app.vi_state.input_mode = InputMode.REPLACE_SINGLE
 
     @handle("R", filter=vi_navigation_mode)
     def _replace_mode(event: E) -> None:
@@ -1882,6 +1882,15 @@ def load_vi_bindings() -> KeyBindingsBase:
         Insert data at cursor position.
         """
         event.current_buffer.insert_text(event.data, overwrite=True)
+
+    @handle(Keys.Any, filter=vi_replace_single_mode)
+    def _replace_single(event: E) -> None:
+        """
+        Replace single character at cursor position.
+        """
+        event.current_buffer.insert_text(event.data, overwrite=True)
+        event.current_buffer.cursor_position -= 1
+        event.app.vi_state.input_mode = InputMode.NAVIGATION
 
     @handle(
         Keys.Any,

--- a/prompt_toolkit/key_binding/vi_state.py
+++ b/prompt_toolkit/key_binding/vi_state.py
@@ -21,6 +21,7 @@ class InputMode(str, Enum):
     INSERT_MULTIPLE = "vi-insert-multiple"
     NAVIGATION = "vi-navigation"  # Normal mode.
     REPLACE = "vi-replace"
+    REPLACE_SINGLE = "vi-replace-single"
 
 
 class CharacterFind:


### PR DESCRIPTION
This would allow to customize cursor shape for single-character replace
mode, similar to how t_SR works in Vim (both for r and R).

See https://github.com/prompt-toolkit/python-prompt-toolkit/issues/192 for examples of cursor-shape customization.