### PR TITLE
Fix auto_suggest key binding when suggestion text is empty.

### DIFF
--- a/prompt_toolkit/key_binding/bindings/auto_suggest.py
+++ b/prompt_toolkit/key_binding/bindings/auto_suggest.py
@@ -31,6 +31,7 @@ def load_auto_suggest_bindings() -> KeyBindings:
         app = get_app()
         return (
             app.current_buffer.suggestion is not None
+            and len(app.current_buffer.suggestion.text) > 0
             and app.current_buffer.document.is_cursor_at_the_end
         )
 


### PR DESCRIPTION
(Commit modified by Jonathan Slenders.)