### PR TITLE
Bug fix for the shift-selection mode

### DIFF
--- a/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/prompt_toolkit/key_binding/bindings/emacs.py
@@ -438,14 +438,13 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
 
         try:
             # Both the dict lookup and `get_by_name` can raise KeyError.
-            handler = get_by_name(key_to_command[key])
+            binding = get_by_name(key_to_command[key])
         except KeyError:
             pass
         else:  # (`else` is not really needed here.)
-            if not isinstance(handler, Binding):
-                # (It should always be a normal callable here, for these
-                # commands.)
-                handler(event)
+            if isinstance(binding, Binding):
+                # (It should always be a binding here)
+                binding.call(event)
 
     @handle("s-left", filter=~has_selection)
     @handle("s-right", filter=~has_selection)


### PR DESCRIPTION
This refers to issue #1157.

`named_commands.py` was modified in commit 148833e982cc0ed427a862e0d2725b353af39d04 on 19 Feb 2020 so that the registering of commands only produces `Bindings`. See excerpt from code below:

https://github.com/prompt-toolkit/python-prompt-toolkit/blob/5f2268d9232f5d300b4a3226c6e82fe44c60f9ca/prompt_toolkit/key_binding/bindings/named_commands.py#L41-L45

The `unshift_move(..)` function in `emacs.py` calls some of the named commands. Previously they were all normal callables, but now that these are bindings, it needs to be modified accordingly. This Pull Request provides this fix. Otherwise most of the shift-selection functionality introduced in commit 9d7e5c8dae4dc3ca200f7ea710ebb on 9 Nov 2019 is blocked. In particular starting a selection with shift-left or shift-right does not work, because the cursor never gets moved.
