### PR TITLE
Alias escape with shift in some emacs key bindings

### DIFF
--- a/prompt_toolkit/input/ansi_escape_sequences.py
+++ b/prompt_toolkit/input/ansi_escape_sequences.py
@@ -267,6 +267,8 @@ ANSI_SEQUENCES: Dict[str, Union[Keys, Tuple[Keys, ...]]] = {
     "\x1b[1;9B": (Keys.Escape, Keys.Down),
     "\x1b[1;9C": (Keys.Escape, Keys.Right),
     "\x1b[1;9D": (Keys.Escape, Keys.Left),
+    "\x1b[1;10C": Keys.EscapeShiftRight,
+    "\x1b[1;10D": Keys.EscapeShiftLeft,
     # --
     # Control/shift/meta + number in mintty.
     # (c-2 will actually send c-@ and c-6 will send c-^.)

--- a/prompt_toolkit/input/ansi_escape_sequences.py
+++ b/prompt_toolkit/input/ansi_escape_sequences.py
@@ -267,8 +267,8 @@ ANSI_SEQUENCES: Dict[str, Union[Keys, Tuple[Keys, ...]]] = {
     "\x1b[1;9B": (Keys.Escape, Keys.Down),
     "\x1b[1;9C": (Keys.Escape, Keys.Right),
     "\x1b[1;9D": (Keys.Escape, Keys.Left),
-    "\x1b[1;10C": Keys.EscapeShiftRight,
-    "\x1b[1;10D": Keys.EscapeShiftLeft,
+    "\x1b[1;10C": (Keys.Escape, Keys.ShiftRight),
+    "\x1b[1;10D": (Keys.Escape, Keys.ShiftLeft),
     # --
     # Control/shift/meta + number in mintty.
     # (c-2 will actually send c-@ and c-6 will send c-^.)

--- a/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/prompt_toolkit/key_binding/bindings/emacs.py
@@ -1,5 +1,5 @@
 # pylint: disable=function-redefined
-from typing import Dict, Union
+from typing import Dict
 
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.buffer import Buffer, SelectionType, indent, unindent
@@ -395,35 +395,35 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
         a shift + movement key press event, moves the cursor
         as if shift is not pressed.
         """
-        key = event.key_sequence[0].key
+        sequence = " ".join([seq.key for seq in event.key_sequence])
 
-        if key == Keys.ShiftUp:
+        if sequence == "s-up":
             event.current_buffer.auto_up(count=event.arg)
             return
-        if key == Keys.ShiftDown:
+        if sequence == "s-down":
             event.current_buffer.auto_down(count=event.arg)
             return
 
         # the other keys are handled through their readline command
-        key_to_command: Dict[Union[Keys, str], str] = {
-            Keys.ShiftLeft: "backward-char",
-            Keys.ShiftRight: "forward-char",
-            Keys.ShiftHome: "beginning-of-line",
-            Keys.ShiftEnd: "end-of-line",
-            Keys.ControlShiftLeft: "backward-word",
-            Keys.ControlShiftRight: "forward-word",
-            Keys.ControlShiftHome: "beginning-of-buffer",
-            Keys.ControlShiftEnd: "end-of-buffer",
-            Keys.EscapeShiftLeft: "backward-word",
-            Keys.EscapeShiftRight: "forward-word",
+        sequence_to_command: Dict[str, str] = {
+            "s-left": "backward-char",
+            "s-right": "forward-char",
+            "s-home": "beginning-of-line",
+            "s-end": "end-of-line",
+            "c-s-left": "backward-word",
+            "c-s-right": "forward-word",
+            "c-s-home": "beginning-of-buffer",
+            "c-s-end": "end-of-buffer",
+            "escape s-left": "backward-word",
+            "escape s-right": "forward-word",
         }
 
         try:
             # Both the dict lookup and `get_by_name` can raise KeyError.
-            binding = get_by_name(key_to_command[key])
+            binding = get_by_name(sequence_to_command[sequence])
         except KeyError:
             pass
-        else:  # (`else` is not really needed here.)
+        else:
             if isinstance(binding, Binding):
                 # (It should always be a binding here)
                 binding.call(event)
@@ -438,8 +438,8 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
     @handle("c-s-right", filter=~has_selection)
     @handle("c-s-home", filter=~has_selection)
     @handle("c-s-end", filter=~has_selection)
-    @handle("e-s-left", filter=~has_selection)
-    @handle("e-s-right", filter=~has_selection)
+    @handle("escape", "s-left", filter=~has_selection)
+    @handle("escape", "s-right", filter=~has_selection)
     def _start_selection(event: E) -> None:
         """
         Start selection with shift + movement.
@@ -472,8 +472,8 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
     @handle("c-s-right", filter=shift_selection_mode)
     @handle("c-s-home", filter=shift_selection_mode)
     @handle("c-s-end", filter=shift_selection_mode)
-    @handle("e-s-left", filter=shift_selection_mode)
-    @handle("e-s-right", filter=shift_selection_mode)
+    @handle("escape", "s-left", filter=shift_selection_mode)
+    @handle("escape", "s-right", filter=shift_selection_mode)
     def _extend_selection(event: E) -> None:
         """
         Extend the selection

--- a/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/prompt_toolkit/key_binding/bindings/emacs.py
@@ -62,6 +62,8 @@ def load_emacs_bindings() -> KeyBindingsBase:
     handle("c-f")(get_by_name("forward-char"))
     handle("c-left")(get_by_name("backward-word"))
     handle("c-right")(get_by_name("forward-word"))
+    handle("escape", "left")(get_by_name("backward-word"))
+    handle("escape", "right")(get_by_name("forward-word"))
     handle("c-x", "r", "y", filter=insert_mode)(get_by_name("yank"))
     handle("c-y", filter=insert_mode)(get_by_name("yank"))
     handle("escape", "b")(get_by_name("backward-word"))
@@ -269,27 +271,6 @@ def load_emacs_bindings() -> KeyBindingsBase:
         data = event.current_buffer.copy_selection()
         event.app.clipboard.set_data(data)
 
-    @handle("escape", "left")
-    def _start_of_word(event: E) -> None:
-        """
-        Cursor to start of previous word.
-        """
-        buffer = event.current_buffer
-        buffer.cursor_position += (
-            buffer.document.find_previous_word_beginning(count=event.arg) or 0
-        )
-
-    @handle("escape", "right")
-    def _start_next_word(event: E) -> None:
-        """
-        Cursor to start of next word.
-        """
-        buffer = event.current_buffer
-        buffer.cursor_position += (
-            buffer.document.find_next_word_beginning(count=event.arg)
-            or buffer.document.get_end_of_document_position()
-        )
-
     @handle("escape", "/", filter=insert_mode)
     def _complete(event: E) -> None:
         """
@@ -433,6 +414,8 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
             Keys.ControlShiftRight: "forward-word",
             Keys.ControlShiftHome: "beginning-of-buffer",
             Keys.ControlShiftEnd: "end-of-buffer",
+            Keys.EscapeShiftLeft: "backward-word",
+            Keys.EscapeShiftRight: "forward-word",
         }
 
         try:
@@ -455,6 +438,8 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
     @handle("c-s-right", filter=~has_selection)
     @handle("c-s-home", filter=~has_selection)
     @handle("c-s-end", filter=~has_selection)
+    @handle("e-s-left", filter=~has_selection)
+    @handle("e-s-right", filter=~has_selection)
     def _start_selection(event: E) -> None:
         """
         Start selection with shift + movement.
@@ -487,6 +472,8 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
     @handle("c-s-right", filter=shift_selection_mode)
     @handle("c-s-home", filter=shift_selection_mode)
     @handle("c-s-end", filter=shift_selection_mode)
+    @handle("e-s-left", filter=shift_selection_mode)
+    @handle("e-s-right", filter=shift_selection_mode)
     def _extend_selection(event: E) -> None:
         """
         Extend the selection
@@ -544,6 +531,8 @@ def load_emacs_shift_selection_bindings() -> KeyBindingsBase:
     @handle("c-right", filter=shift_selection_mode)
     @handle("c-home", filter=shift_selection_mode)
     @handle("c-end", filter=shift_selection_mode)
+    @handle("escape", "left", filter=shift_selection_mode)
+    @handle("escape", "right", filter=shift_selection_mode)
     def _cancel(event: E) -> None:
         """
         Cancel selection.

--- a/prompt_toolkit/key_binding/bindings/named_commands.py
+++ b/prompt_toolkit/key_binding/bindings/named_commands.py
@@ -114,7 +114,9 @@ def forward_char(event: E) -> None:
 
 @register("backward-char")
 def backward_char(event: E) -> None:
-    " Move back a character. "
+    """
+    Move back a character.
+    """
     buff = event.current_buffer
     buff.cursor_position += buff.document.get_cursor_left_position(count=event.arg)
 

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -120,9 +120,6 @@ class Keys(str, Enum):
     ControlShiftPageUp = "c-s-pageup"
     ControlShiftPageDown = "c-s-pagedown"
 
-    EscapeShiftLeft = "e-s-left"
-    EscapeShiftRight = "e-s-right"
-
     BackTab = "s-tab"  # shift + tab
 
     F1 = "f1"

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -120,6 +120,9 @@ class Keys(str, Enum):
     ControlShiftPageUp = "c-s-pageup"
     ControlShiftPageDown = "c-s-pagedown"
 
+    EscapeShiftLeft = "e-s-left"
+    EscapeShiftRight = "e-s-right"
+
     BackTab = "s-tab"  # shift + tab
 
     F1 = "f1"


### PR DESCRIPTION
I use a mac, and my fingers like Option more than Control (since it's slightly closer to my thumb). Most text editors alias Ctrl-Left with Option-Left, might be nice if PTK did the same.

Upon rereading, I'm a tad worried I'm missing nuances between Ctrl and Option, lemme know if I'm just imagining them!