### PR TITLE
Pre selected items radiolist_dialog & checkboxlist_dialog

### DIFF
--- a/docs/pages/dialogs.rst
+++ b/docs/pages/dialogs.rst
@@ -98,14 +98,15 @@ each providing the return value (first element) and the displayed value (second 
 
     from prompt_toolkit.shortcuts import radiolist_dialog
 
-    result = radiolist_dialog( 
-        title="RadioList dialog", 
-        text="Which breakfast would you like ?", 
-        values=[ 
-            ("breakfast1", "Eggs and beacon"), 
-            ("breakfast2", "French breakfast"), 
-            ("breakfast3", "Equestrian breakfast") 
-        ] 
+    result = radiolist_dialog(
+        title="RadioList dialog",
+        text="Which breakfast would you like ?",
+        values=[
+            ("breakfast1", "Eggs and beacon"),
+            ("breakfast2", "French breakfast"),
+            ("breakfast3", "Equestrian breakfast")
+        ],
+        initial_selected='breakfast2'
     ).run()
 
 
@@ -118,15 +119,16 @@ The :func:`~prompt_toolkit.shortcuts.checkboxlist_dialog` has the same usage and
 
     from prompt_toolkit.shortcuts import checkboxlist_dialog
 
-    results_array = checkboxlist_dialog( 
-        title="CheckboxList dialog", 
+    results_array = checkboxlist_dialog(
+        title="CheckboxList dialog",
         text="What would you like in your breakfast ?",
-        values=[ 
+        values=[
             ("eggs", "Eggs"),
             ("bacon", "Bacon"),
             ("croissants", "20 Croissants"),
             ("daily", "The breakfast of the day")
-        ] 
+        ],
+        initial_selected=['eggs', 'croissants']
     ).run()
 
 

--- a/prompt_toolkit/shortcuts/dialogs.py
+++ b/prompt_toolkit/shortcuts/dialogs.py
@@ -177,6 +177,7 @@ def radiolist_dialog(
     cancel_text: str = "Cancel",
     values: Optional[List[Tuple[_T, AnyFormattedText]]] = None,
     style: Optional[BaseStyle] = None,
+    initial_selected: Optional[_T] = None,
 ) -> Application[_T]:
     """
     Display a simple list of element the user can choose amongst.
@@ -191,6 +192,9 @@ def radiolist_dialog(
         get_app().exit(result=radio_list.current_value)
 
     radio_list = RadioList(values)
+
+    if initial_selected:
+        radio_list.current_value = initial_selected
 
     dialog = Dialog(
         title=title,
@@ -215,6 +219,7 @@ def checkboxlist_dialog(
     cancel_text: str = "Cancel",
     values: Optional[List[Tuple[_T, AnyFormattedText]]] = None,
     style: Optional[BaseStyle] = None,
+    initial_selected: Optional[List[_T]] = None,
 ) -> Application[List[_T]]:
     """
     Display a simple list of element the user can choose multiple values amongst.
@@ -229,6 +234,9 @@ def checkboxlist_dialog(
         get_app().exit(result=cb_list.current_values)
 
     cb_list = CheckboxList(values)
+
+    if initial_selected:
+        cb_list.current_values = initial_selected
 
     dialog = Dialog(
         title=title,


### PR DESCRIPTION
This merge requests adds an argument `initial_selected` to the [`checkboxlist_dialog`](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/4c2fb15e7f4838d46467b0ca193ae6d543b4172a/prompt_toolkit/shortcuts/dialogs.py#L211) and [`radiolist_dialog`](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/4c2fb15e7f4838d46467b0ca193ae6d543b4172a/prompt_toolkit/shortcuts/dialogs.py#L173) like requested in #1196.