### PR TITLE
Add missing import to progress bar keybindings example

### DIFF
--- a/docs/pages/progress_bars.rst
+++ b/docs/pages/progress_bars.rst
@@ -201,7 +201,9 @@ passing a :class:`~prompt_toolkit.key_binding.KeyBindings` object:
     from prompt_toolkit.patch_stdout import patch_stdout
     from prompt_toolkit.shortcuts import ProgressBar
 
+    import os
     import time
+    import signal
 
     bottom_toolbar = HTML(' <b>[f]</b> Print "f" <b>[x]</b> Abort.')
 


### PR DESCRIPTION
The progress bar key bindings example in the documentation had some missing imports