### PR TITLE
Keys: add space to enum

### DIFF
--- a/prompt_toolkit/key_binding/bindings/completion.py
+++ b/prompt_toolkit/key_binding/bindings/completion.py
@@ -179,9 +179,9 @@ def _create_more_session(message: str = "--MORE--") -> "PromptSession":
 
     bindings = KeyBindings()
 
-    @bindings.add(" ")
     @bindings.add("y")
     @bindings.add("Y")
+    @bindings.add(Keys.Space)
     @bindings.add(Keys.ControlJ)
     @bindings.add(Keys.ControlM)
     @bindings.add(Keys.ControlI)  # Tab.

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -19,6 +19,7 @@ class Keys(str, Enum):
 
     Escape = "escape"  # Also Control-[
     ShiftEscape = "s-escape"
+    Space = " "
 
     ControlAt = "c-@"  # Also Control-Space.
 

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -422,8 +422,8 @@ class Button:
         " Key bindings for the Button. "
         kb = KeyBindings()
 
-        @kb.add(" ")
         @kb.add("enter")
+        @kb.add(Keys.Space)
         def _(event: E) -> None:
             if self.handler is not None:
                 self.handler()
@@ -692,7 +692,7 @@ class _DialogList(Generic[_T]):
                 )
 
         @kb.add("enter")
-        @kb.add(" ")
+        @kb.add(Keys.Space)
         def _click(event: E) -> None:
             self._handle_enter()
 


### PR DESCRIPTION
Having to add an empty string isn't really clear that it means the
spacebar, I think adding to the enums would make it more explicit.