### PR TITLE
Prevent asyncio DeprecationWarning

### DIFF
--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -2,7 +2,7 @@
 Renders the command line on the console.
 (Redraws parts of the input line that were changed.)
 """
-from asyncio import FIRST_COMPLETED, Future, sleep, wait
+from asyncio import FIRST_COMPLETED, Future, create_task, sleep, wait
 from collections import deque
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Hashable, Optional, Tuple
@@ -566,11 +566,11 @@ class Renderer:
                 response_f.cancel()
             self._waiting_for_cpr_futures = deque()
 
-        coroutines = [
-            wait_for_responses(),
-            wait_for_timeout(),
-        ]
-        _, pending = await wait(coroutines, return_when=FIRST_COMPLETED)
+        tasks = {
+            create_task(wait_for_responses()),
+            create_task(wait_for_timeout()),
+        }
+        _, pending = await wait(tasks, return_when=FIRST_COMPLETED)
         for task in pending:
             task.cancel()
 

--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -2,7 +2,7 @@
 Renders the command line on the console.
 (Redraws parts of the input line that were changed.)
 """
-from asyncio import FIRST_COMPLETED, Future, create_task, sleep, wait
+from asyncio import FIRST_COMPLETED, Future, ensure_future, sleep, wait
 from collections import deque
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Hashable, Optional, Tuple
@@ -567,8 +567,8 @@ class Renderer:
             self._waiting_for_cpr_futures = deque()
 
         tasks = {
-            create_task(wait_for_responses()),
-            create_task(wait_for_timeout()),
+            ensure_future(wait_for_responses()),
+            ensure_future(wait_for_timeout()),
         }
         _, pending = await wait(tasks, return_when=FIRST_COMPLETED)
         for task in pending:


### PR DESCRIPTION
Under some circumstances (see <https://github.com/xonsh/xonsh/issues/3907>) a DeprecationWarning would be printed. This is because of passing coroutine objects directly to asyncio.wait(), which is confusing behaviour that has been deprecated.

<https://github.com/python/cpython/pull/9543> gives information on how to refactor code that uses the deprecated method.

Fixes https://github.com/xonsh/xonsh/issues/3907