### PR TITLE
add TERM=linux escape sequence for c-tab

### DIFF
--- a/prompt_toolkit/input/ansi_escape_sequences.py
+++ b/prompt_toolkit/input/ansi_escape_sequences.py
@@ -74,6 +74,7 @@ ANSI_SEQUENCES: Dict[str, Union[Keys, Tuple[Keys, ...]]] = {
     "\x1b[7~": Keys.Home,  # xrvt
     "\x1b[8~": Keys.End,  # xrvt
     "\x1b[Z": Keys.BackTab,  # shift + tab
+    "\x1b\x09":  Keys.BackTab,  # Linux console
     # --
     # Function keys.
     "\x1bOP": Keys.F1,


### PR DESCRIPTION
Proposed fix for #1294.