### PR TITLE
added Completion objects support for Word and Nested completers

### DIFF
--- a/prompt_toolkit/completion/base.py
+++ b/prompt_toolkit/completion/base.py
@@ -87,7 +87,7 @@ class Completion:
         )
 
     def __hash__(self) -> int:
-        return hash((self.text, self.start_position, self.display, self._display_meta))
+        return hash((self.text, self.start_position, self.style))
 
     @property
     def display_text(self) -> str:

--- a/prompt_toolkit/completion/nested.py
+++ b/prompt_toolkit/completion/nested.py
@@ -10,7 +10,7 @@ from prompt_toolkit.document import Document
 __all__ = ["NestedCompleter"]
 
 # NestedDict = Mapping[str, Union['NestedDict', Set[str], None, Completer]]
-NestedDict = Mapping[str, Union[Any, Set[str], None, Completer]]
+NestedDict = Mapping[Union[str, Completion], Union[Any, Set[str], None, Completer]]
 
 
 class NestedCompleter(Completer):
@@ -86,6 +86,10 @@ class NestedCompleter(Completer):
         if " " in text:
             first_term = text.split()[0]
             completer = self.options.get(first_term)
+            if completer is None:
+               matching =  (c for c in self.options.keys() if
+                            isinstance(c, Completion) and c.text==first_term)
+               completer =  self.options.get(next(matching, None))
 
             # If we have a sub completer, use this for the completions.
             if completer is not None:

--- a/prompt_toolkit/completion/word_completer.py
+++ b/prompt_toolkit/completion/word_completer.py
@@ -30,7 +30,7 @@ class WordCompleter(Completer):
 
     def __init__(
         self,
-        words: Union[List[str], Callable[[], List[str]]],
+        words: Union[List[Union[str, Completion]], Callable[[], Union[str, Completion]]],
         ignore_case: bool = False,
         meta_dict: Optional[Dict[str, str]] = None,
         WORD: bool = False,
@@ -78,7 +78,12 @@ class WordCompleter(Completer):
             else:
                 return word.startswith(word_before_cursor)
 
+        start_position = -len(word_before_cursor)
         for a in words:
-            if word_matches(a):
+            if isinstance(a, Completion):
+                if word_matches(a.text):
+                    a.start_position = start_position
+                    yield(a)
+            elif word_matches(a):
                 display_meta = self.meta_dict.get(a, "")
-                yield Completion(a, -len(word_before_cursor), display_meta=display_meta)
+                yield Completion(a, start_position, display_meta=display_meta)


### PR DESCRIPTION
Allow to easily style WordCompleter and NestedCompleter completion prompts 

![exampleColorNested](https://user-images.githubusercontent.com/24274639/101220625-4bca5180-3686-11eb-9f57-81e4e2911d3c.png)

obtained with this code example:

```python
#!/usr/bin/env python3

from prompt_toolkit import prompt
from prompt_toolkit.completion import Completer, NestedCompleter, Completion

completer = NestedCompleter.from_nested_dict({
    Completion('colors', style="bold italic"): {
        Completion('blue', style="fg:ansiblue"): None,
        Completion('red', style="fg:ansired"): None,
        Completion('green', style="fg:ansigreen"): None
    },
    'normal': {'classic', 'strings', 'working'}
})

text = prompt('# ', completer=completer)
print('You said: %s' % text)
```

Also fixed bug where Completion could not be hashable. but there may be some risks of duplicates, please review.

My use case:
I just finished Advent of code 2019 (day 25), wich is a text-adventure game.
I wanted create a prompt which gives me completion of all available actions (in the style "go south", "take matches")
But I wanted the game to hint me for certain actions, like greying "south" if I already went there, or highlight some items in red to mark some sort of danger.
