### PR TITLE
setup.py: Add trove classifier for Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python",
         "Topic :: Software Development",


### PR DESCRIPTION
Add support for Python 3.9 to the lower left of https://pypi.org/project/prompt-toolkit/

Tests have been passing on Python 3.9
https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/.github/workflows/test.yaml#L13