### PR TITLE
Refactoring of patch_stdout.

### DIFF
--- a/prompt_toolkit/output/base.py
+++ b/prompt_toolkit/output/base.py
@@ -2,6 +2,7 @@
 Interface for an output.
 """
 from abc import ABCMeta, abstractmethod
+from typing import Optional, TextIO
 
 from prompt_toolkit.data_structures import Size
 from prompt_toolkit.styles import Attrs
@@ -23,6 +24,8 @@ class Output(metaclass=ABCMeta):
     :class:`~prompt_toolkit.output.vt100.Vt100_Output` and
     :class:`~prompt_toolkit.output.win32.Win32Output`.
     """
+
+    stdout: Optional[TextIO] = None
 
     @abstractmethod
     def fileno(self) -> int:

--- a/prompt_toolkit/output/defaults.py
+++ b/prompt_toolkit/output/defaults.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Optional, TextIO, cast
 
-from prompt_toolkit.patch_stdout import StdoutProxy
 from prompt_toolkit.utils import (
     get_term_environment_variable,
     is_conemu_ansi,
@@ -49,6 +48,8 @@ def create_output(
     # If the patch_stdout context manager has been used, then sys.stdout is
     # replaced by this proxy. For prompt_toolkit applications, we want to use
     # the real stdout.
+    from prompt_toolkit.patch_stdout import StdoutProxy
+
     while isinstance(stdout, StdoutProxy):
         stdout = stdout.original_stdout
 

--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -427,7 +427,7 @@ class Vt100_Output(Output):
             assert hasattr(stdout, "encoding")
 
         self._buffer: List[str] = []
-        self.stdout = stdout
+        self.stdout: TextIO = stdout
         self.write_binary = write_binary
         self.default_color_depth = default_color_depth
         self._get_size = get_size

--- a/prompt_toolkit/output/win32.py
+++ b/prompt_toolkit/output/win32.py
@@ -95,7 +95,7 @@ class Win32Output(Output):
         self.default_color_depth = default_color_depth
 
         self._buffer: List[str] = []
-        self.stdout = stdout
+        self.stdout: TextIO = stdout
         self.hconsole = HANDLE(windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE))
 
         self._in_alternate_screen = False


### PR DESCRIPTION
- Look at the AppSession in order to see which application is running, rather
  then looking at the event loop which is installed when `StdoutProxy` is
  created. This way, `patch_stdout` will work when prompt_toolkit applications
  with a different event loop run.
- Fix printing when no application/event loop is running.
- Use a background thread for flushing output to the application. The current
  code should be more performant on big outputs.
- `PatchStdout` itself is now a context manager. It also requires closing when
  done (which will terminate the daemon thread).
- Fixed the `raw` argument of `PatchStdout`.