### PR TITLE
Refactoring of history code.

### DIFF
--- a/prompt_toolkit/layout/controls.py
+++ b/prompt_toolkit/layout/controls.py
@@ -737,6 +737,14 @@ class BufferControl(UIControl):
         """
         buffer = self.buffer
 
+        # Trigger history loading of the buffer. We do this during the
+        # rendering of the UI here, because it needs to happen when an
+        # `Application` with its event loop is running. During the rendering of
+        # the buffer control is the earliest place we can achieve this, where
+        # we're sure the right event loop is active, and don't require user
+        # interaction (like in a key binding).
+        buffer.load_history_if_not_yet_loaded()
+
         # Get the document to be shown. If we are currently searching (the
         # search buffer has focus, and the preview_search filter is enabled),
         # then use the search document, which has possibly a different

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,101 @@
+import asyncio
+
+from prompt_toolkit.history import FileHistory, InMemoryHistory, ThreadedHistory
+
+
+def _call_history_load(history):
+    """
+    Helper: Call the history "load" method and return the result as a list of strings.
+    """
+    result = []
+
+    async def call_load():
+        async for item in history.load():
+            result.append(item)
+
+    asyncio.get_event_loop().run_until_complete(call_load())
+    return result
+
+
+def test_in_memory_history():
+    history = InMemoryHistory()
+    history.append_string("hello")
+    history.append_string("world")
+
+    # Newest should yield first.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    # Test another call.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    history.append_string("test3")
+    assert _call_history_load(history) == ["test3", "world", "hello"]
+
+    # Passing history as a parameter.
+    history2 = InMemoryHistory(["abc", "def"])
+    assert _call_history_load(history2) == ["def", "abc"]
+
+
+def test_file_history(tmpdir):
+    histfile = tmpdir.join("history")
+
+    history = FileHistory(histfile)
+
+    history.append_string("hello")
+    history.append_string("world")
+
+    # Newest should yield first.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    # Test another call.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    history.append_string("test3")
+    assert _call_history_load(history) == ["test3", "world", "hello"]
+
+    # Create another history instance pointing to the same file.
+    history2 = FileHistory(histfile)
+    assert _call_history_load(history2) == ["test3", "world", "hello"]
+
+
+def test_threaded_file_history(tmpdir):
+    histfile = tmpdir.join("history")
+
+    history = ThreadedHistory(FileHistory(histfile))
+
+    history.append_string("hello")
+    history.append_string("world")
+
+    # Newest should yield first.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    # Test another call.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    history.append_string("test3")
+    assert _call_history_load(history) == ["test3", "world", "hello"]
+
+    # Create another history instance pointing to the same file.
+    history2 = ThreadedHistory(FileHistory(histfile))
+    assert _call_history_load(history2) == ["test3", "world", "hello"]
+
+
+def test_threaded_in_memory_history():
+    # Threaded in memory history is not useful. But testing it anyway, just to
+    # see whether everything plays nicely together.
+    history = ThreadedHistory(InMemoryHistory())
+    history.append_string("hello")
+    history.append_string("world")
+
+    # Newest should yield first.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    # Test another call.
+    assert _call_history_load(history) == ["world", "hello"]
+
+    history.append_string("test3")
+    assert _call_history_load(history) == ["test3", "world", "hello"]
+
+    # Passing history as a parameter.
+    history2 = ThreadedHistory(InMemoryHistory(["abc", "def"]))
+    assert _call_history_load(history2) == ["def", "abc"]


### PR DESCRIPTION
- Fix race condition in ThreadedHistory. Fixes issue #1158.
- Refactored the history code so that asynchronous history loader
  implementations become possible.
- Start loading the history when the `BufferControl` renders for the first
  time. This way we are sure that the history loading uses the same event loop
  as the one used by the application.
- Added unit tests.
- Make it possible to wrap `InMemoryHistory` in `ThreadedHistory` (not useful,
  but good if all combinations work).