### PR TITLE
Disable bell with environment variable

### DIFF
--- a/prompt_toolkit/output/defaults.py
+++ b/prompt_toolkit/output/defaults.py
@@ -78,5 +78,5 @@ def create_output(
             stdout,
             term=term_from_env,
             default_color_depth=color_depth_from_env,
-            bell=bell_from_env,
+            enable_bell=bell_from_env,
         )

--- a/prompt_toolkit/output/defaults.py
+++ b/prompt_toolkit/output/defaults.py
@@ -75,5 +75,8 @@ def create_output(
         from .vt100 import Vt100_Output
 
         return Vt100_Output.from_pty(
-            stdout, term=term_from_env, default_color_depth=color_depth_from_env, bell=bell_from_env,
+            stdout,
+            term=term_from_env,
+            default_color_depth=color_depth_from_env,
+            bell=bell_from_env,
         )

--- a/prompt_toolkit/output/defaults.py
+++ b/prompt_toolkit/output/defaults.py
@@ -2,6 +2,7 @@ import sys
 from typing import Optional, TextIO, cast
 
 from prompt_toolkit.utils import (
+    get_bell_environment_variable,
     get_term_environment_variable,
     is_conemu_ansi,
     is_windows,
@@ -28,10 +29,11 @@ def create_output(
         consumed by something other then a terminal, so this is a reasonable
         default.)
     """
-    # Consider TERM and PROMPT_TOOLKIT_COLOR_DEPTH environment variables.
-    # Notice that PROMPT_TOOLKIT_COLOR_DEPTH value is the default that's used
-    # if the Application doesn't override it.
+    # Consider TERM, PROMPT_TOOLKIT_BELL, and PROMPT_TOOLKIT_COLOR_DEPTH
+    # environment variables. Notice that PROMPT_TOOLKIT_COLOR_DEPTH value is
+    # the default that's used if the Application doesn't override it.
     term_from_env = get_term_environment_variable()
+    bell_from_env = get_bell_environment_variable()
     color_depth_from_env = ColorDepth.from_env()
 
     if stdout is None:
@@ -73,5 +75,5 @@ def create_output(
         from .vt100 import Vt100_Output
 
         return Vt100_Output.from_pty(
-            stdout, term=term_from_env, default_color_depth=color_depth_from_env
+            stdout, term=term_from_env, default_color_depth=color_depth_from_env, bell=bell_from_env,
         )

--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -488,7 +488,13 @@ class Vt100_Output(Output):
                 pass
             return Size(rows=rows or 24, columns=columns or 80)
 
-        return cls(stdout, get_size, term=term, default_color_depth=default_color_depth, bell=bell)
+        return cls(
+            stdout,
+            get_size,
+            term=term,
+            default_color_depth=default_color_depth,
+            bell=bell,
+        )
 
     def get_size(self) -> Size:
         return self._get_size()

--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -419,7 +419,7 @@ class Vt100_Output(Output):
         term: Optional[str] = None,
         write_binary: bool = True,
         default_color_depth: Optional[ColorDepth] = None,
-        bell: bool = True,
+        enable_bell: bool = True,
     ) -> None:
 
         assert all(hasattr(stdout, a) for a in ("write", "flush"))
@@ -433,7 +433,7 @@ class Vt100_Output(Output):
         self.default_color_depth = default_color_depth
         self._get_size = get_size
         self.term = term
-        self.beep = bell
+        self.enable_bell = enable_bell
 
         # Cache for escape codes.
         self._escape_code_caches: Dict[ColorDepth, _EscapeCodeCache] = {
@@ -449,7 +449,7 @@ class Vt100_Output(Output):
         stdout: TextIO,
         term: Optional[str] = None,
         default_color_depth: Optional[ColorDepth] = None,
-        bell: bool = True,
+        enable_bell: bool = True,
     ) -> "Vt100_Output":
         """
         Create an Output class from a pseudo terminal.
@@ -493,7 +493,7 @@ class Vt100_Output(Output):
             get_size,
             term=term,
             default_color_depth=default_color_depth,
-            bell=bell,
+            enable_bell=enable_bell,
         )
 
     def get_size(self) -> Size:
@@ -727,7 +727,7 @@ class Vt100_Output(Output):
 
     def bell(self) -> None:
         " Sound bell. "
-        if self.beep:
+        if self.enable_bell:
             self.write_raw("\a")
             self.flush()
 

--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -419,6 +419,7 @@ class Vt100_Output(Output):
         term: Optional[str] = None,
         write_binary: bool = True,
         default_color_depth: Optional[ColorDepth] = None,
+        bell: bool = True,
     ) -> None:
 
         assert all(hasattr(stdout, a) for a in ("write", "flush"))
@@ -432,6 +433,7 @@ class Vt100_Output(Output):
         self.default_color_depth = default_color_depth
         self._get_size = get_size
         self.term = term
+        self.beep = bell
 
         # Cache for escape codes.
         self._escape_code_caches: Dict[ColorDepth, _EscapeCodeCache] = {
@@ -447,6 +449,7 @@ class Vt100_Output(Output):
         stdout: TextIO,
         term: Optional[str] = None,
         default_color_depth: Optional[ColorDepth] = None,
+        bell: bool = True,
     ) -> "Vt100_Output":
         """
         Create an Output class from a pseudo terminal.
@@ -485,7 +488,7 @@ class Vt100_Output(Output):
                 pass
             return Size(rows=rows or 24, columns=columns or 80)
 
-        return cls(stdout, get_size, term=term, default_color_depth=default_color_depth)
+        return cls(stdout, get_size, term=term, default_color_depth=default_color_depth, bell=bell)
 
     def get_size(self) -> Size:
         return self._get_size()
@@ -718,8 +721,9 @@ class Vt100_Output(Output):
 
     def bell(self) -> None:
         " Sound bell. "
-        self.write_raw("\a")
-        self.flush()
+        if self.beep:
+            self.write_raw("\a")
+            self.flush()
 
     def get_default_color_depth(self) -> ColorDepth:
         """

--- a/prompt_toolkit/utils.py
+++ b/prompt_toolkit/utils.py
@@ -26,6 +26,7 @@ __all__ = [
     "is_conemu_ansi",
     "is_windows",
     "in_main_thread",
+    "get_bell_environment_variable",
     "get_term_environment_variable",
     "take_using_weights",
     "to_str",
@@ -208,6 +209,14 @@ def in_main_thread() -> bool:
     True when the current thread is the main thread.
     """
     return threading.current_thread().__class__.__name__ == "_MainThread"
+
+
+def get_bell_environment_variable() -> bool:
+    """
+    True if env variable is set to true (true, TRUE, TrUe, 1).
+    """
+    value = os.environ.get("PROMPT_TOOLKIT_BELL", "true")
+    return value.lower() in ("1", "true")
 
 
 def get_term_environment_variable() -> str:


### PR DESCRIPTION
I have that annoying beep on editing read-only buffer. Blacklisting `pcspkr` kernel module is not an option for me (it has global effect). This PR allows to configure beeping with `PROMPT_TOOLKIT_BELL` environment variable. Probably event better solution would be parsing `.inputrc` for bell configuration. Run the following for testing.

```shell
PROMPT_TOOLKIT_BELL=false ipython  # turn off beeping
```

Related issues are #363, ipython/ipython#11626, and ipython/ipython#12196.