### PR TITLE
Buffer._set_cursor_position(): Fix return value for negative arguments

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -464,7 +464,7 @@ class Buffer:
         original_position = self.__cursor_position
         self.__cursor_position = max(0, value)
 
-        return value != original_position
+        return self.__cursor_position != original_position
 
     @property
     def text(self) -> str:


### PR DESCRIPTION
I don't know if it's a bugfix, but this is more correct.