### PR TITLE
Guarantee height of at least 1 for both labels and text areas.

### DIFF
--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -263,6 +263,10 @@ class TextArea:
 
         style = "class:text-area " + style
 
+        # If no height was given, guarantee height of at least 1.
+        if height is None:
+            height = D(min=1)
+
         self.window = Window(
             height=height,
             width=width,
@@ -352,6 +356,7 @@ class Label:
         self.window = Window(
             content=self.formatted_text_control,
             width=get_width,
+            height=D(min=1),
             style="class:label " + style,
             dont_extend_height=dont_extend_height,
             dont_extend_width=dont_extend_width,


### PR DESCRIPTION
This solves an issue where we have a `VSplit`, consisting of many labels, with
a precize padding value given. If the window is too small, then the padding
will take up all the space (because the dimension is "exact"), and no space
will remain for the labels (where the minimum size given was 0 instead of 1).

It doesn't make sense for labels and text areas to have a zero size, so we
increase this to 1.