### PR TITLE
Docs: fix misused automodule directive in docs/pages/reference.rst

### DIFF
--- a/docs/pages/reference.rst
+++ b/docs/pages/reference.rst
@@ -132,44 +132,116 @@ Lexers
 Layout
 ------
 
+.. automodule:: prompt_toolkit.layout
+
 The layout class itself
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: prompt_toolkit.layout
-    :members: Layout, InvalidLayoutError, walk
+.. autoclass:: prompt_toolkit.layout.Layout
 
+.. autoclass:: prompt_toolkit.layout.InvalidLayoutError
+
+.. autoclass:: prompt_toolkit.layout.walk
 
 Containers
 ^^^^^^^^^^
 
-.. automodule:: prompt_toolkit.layout
-    :members: Container, HSplit, VSplit, FloatContainer, Float, Window,
-        WindowAlign, ConditionalContainer, DynamicContainer, ScrollOffsets,
-        ColorColumn, to_container, to_window, is_container, HorizontalAlign,
-        VerticalAlign
+.. autoclass:: prompt_toolkit.layout.Container
 
+.. autoclass:: prompt_toolkit.layout.HSplit
+
+.. autoclass:: prompt_toolkit.layout.VSplit
+
+.. autoclass:: prompt_toolkit.layout.FloatContainer
+
+.. autoclass:: prompt_toolkit.layout.Float
+
+.. autoclass:: prompt_toolkit.layout.Window
+
+.. autoclass:: prompt_toolkit.layout.WindowAlign
+
+.. autoclass:: prompt_toolkit.layout.ConditionalContainer
+
+.. autoclass:: prompt_toolkit.layout.DynamicContainer
+
+.. autoclass:: prompt_toolkit.layout.ScrollOffsets
+
+.. autoclass:: prompt_toolkit.layout.ColorColumn
+
+.. autoclass:: prompt_toolkit.layout.to_container
+
+.. autoclass:: prompt_toolkit.layout.to_window
+
+.. autoclass:: prompt_toolkit.layout.is_container
+
+.. autoclass:: prompt_toolkit.layout.HorizontalAlign
+
+.. autoclass:: prompt_toolkit.layout.VerticalAlign
 
 Controls
 ^^^^^^^^
 
-.. automodule:: prompt_toolkit.layout
-    :members: BufferControl, SearchBufferControl, DummyControl,
-        FormattedTextControl, UIControl, UIContent
+.. autoclass:: prompt_toolkit.layout.BufferControl
+
+.. autoclass:: prompt_toolkit.layout.SearchBufferControl
+
+.. autoclass:: prompt_toolkit.layout.DummyControl
+
+.. autoclass:: prompt_toolkit.layout.FormattedTextControl
+
+.. autoclass:: prompt_toolkit.layout.UIControl
+
+.. autoclass:: prompt_toolkit.layout.UIContent
 
 
 Other
 ^^^^^
 
-.. automodule:: prompt_toolkit.layout
-    :members: Dimension, Margin, NumberedMargin, ScrollbarMargin,
-        ConditionalMargin, PromptMargin, CompletionsMenu,
-        MultiColumnCompletionsMenu
+
+Sizing
+""""""
+
+.. autoclass:: prompt_toolkit.layout.Dimension
+
+
+Margins
+"""""""
+
+.. autoclass:: prompt_toolkit.layout.Margin
+
+.. autoclass:: prompt_toolkit.layout.NumberedMargin
+
+.. autoclass:: prompt_toolkit.layout.ScrollbarMargin
+
+.. autoclass:: prompt_toolkit.layout.ConditionalMargin
+
+.. autoclass:: prompt_toolkit.layout.PromptMargin
+
+
+Completion Menus
+""""""""""""""""
+
+.. autoclass:: prompt_toolkit.layout.CompletionsMenu
+
+.. autoclass:: prompt_toolkit.layout.MultiColumnCompletionsMenu
+
+
+Processors
+""""""""""
 
 .. automodule:: prompt_toolkit.layout.processors
     :members:
 
+
+Utils
+"""""
+
 .. automodule:: prompt_toolkit.layout.utils
     :members:
+
+
+Screen
+""""""
 
 .. automodule:: prompt_toolkit.layout.screen
     :members:

--- a/docs/pages/reference.rst
+++ b/docs/pages/reference.rst
@@ -82,10 +82,8 @@ Style
 .. automodule:: prompt_toolkit.styles
     :members: Attrs, ANSI_COLOR_NAMES, BaseStyle, DummyStyle, DynamicStyle,
         Style, Priority, merge_styles, style_from_pygments_cls,
-        style_from_pygments_dict, pygments_token_to_classname, NAMED_COLORS
-
-.. automodule:: prompt_toolkit.styles
-    :members: StyleTransformation, SwapLightAndDarkStyleTransformation,
+        style_from_pygments_dict, pygments_token_to_classname, NAMED_COLORS,
+        StyleTransformation, SwapLightAndDarkStyleTransformation,
         AdjustBrightnessStyleTransformation, merge_style_transformations,
         DummyStyleTransformation, ConditionalStyleTransformation,
         DynamicStyleTransformation


### PR DESCRIPTION
TL;DR: "Reference" section of the docs: `.. autmodule::` → `.. autoclass::` where needed, add some headings to "Layout" to make it easier to navigate.

The [Layout](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/91916569efb0e3c6709930c08760755d756844da/docs/pages/reference.rst#layout) section in the docs RST source uses `.. automodule::` multiple times, each time adding the same module docstring to the generated documentation. This makes for bugs in the TOC tree, menu JS, as well as anchors:

![image](https://user-images.githubusercontent.com/6691643/107134123-725b7180-68ef-11eb-994f-89e81dc819b8.png)

"Style" section had similar problem, but it was a lot less pronounced, since `prompt_toolkit.styles` module docstring is quite sparse at the moment.

This PR fixes it by replacing `.. autmodule::`  with  `.. autoclass::` where the former was duplicated, namely in "Style" and "Layout" sections. 

Headings under "Other" subsection of "Layouts" were added, to improve navigation.

See [Sphinx autodoc docs](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directives) for reference.