### PR TITLE
Docs: FormattedTextControl.preferred_height

### DIFF
--- a/prompt_toolkit/layout/controls.py
+++ b/prompt_toolkit/layout/controls.py
@@ -375,7 +375,9 @@ class FormattedTextControl(UIControl):
         wrap_lines: bool,
         get_line_prefix: Optional[GetLinePrefixCallable],
     ) -> Optional[int]:
-
+        """
+        Return the preferred height for this control.
+        """
         content = self.create_content(width, None)
         if wrap_lines:
             height = 0


### PR DESCRIPTION
`FormattedTextControl.preferred_height` was missing a docstring, which made the whole method hidden in the reference. This was weird mainly because it implied that this class only uses `preferred_width`, since that one was actually visible.

See [`FormattedTextControl` in the docs](https://python-prompt-toolkit.readthedocs.io/en/master/pages/reference.html#prompt_toolkit.layout.FormattedTextControl).