### PR TITLE
Docs: fix links to prompt-toolkit organisation on GitHub

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,7 +56,7 @@ Thanks to:
 ----------
 
 A special thanks to `all the contributors
-<https://github.com/prompt_toolkit/python-prompt-toolkit/graphs/contributors>`_
+<https://github.com/prompt-toolkit/python-prompt-toolkit/graphs/contributors>`_
 for making prompt_toolkit possible.
 
 Also, a special thanks to the `Pygments <http://pygments.org/>`_ and `wcwidth
@@ -90,4 +90,4 @@ Indices and tables
 * :ref:`search`
 
 Prompt_toolkit was created by `Jonathan Slenders
-<http://github.com/prompt_toolkit/>`_.
+<http://github.com/prompt-toolkit/>`_.

--- a/docs/pages/getting_started.rst
+++ b/docs/pages/getting_started.rst
@@ -24,8 +24,8 @@ Several use cases: prompts versus full screen terminal applications
 However, when it became more mature, we realised that all the components for
 full screen applications are there and `prompt_toolkit` is very capable of
 handling many use situations. `Pyvim
-<http://github.com/prompt_toolkit/pyvim>`_ and `pymux
-<http://github.com/prompt_toolkit/pymux>`_ are examples of full screen
+<http://github.com/prompt-toolkit/pyvim>`_ and `pymux
+<http://github.com/prompt-toolkit/pymux>`_ are examples of full screen
 applications.
 
 .. image:: ../images/pyvim.png
@@ -66,7 +66,7 @@ Learning `prompt_toolkit`
 In order to learn and understand `prompt_toolkit`, it is best to go through the
 all sections in the order below. Also don't forget to have a look at all the
 `examples
-<https://github.com/prompt_toolkit/python-prompt-toolkit/tree/master/examples>`_
+<https://github.com/prompt-toolkit/python-prompt-toolkit/tree/master/examples>`_
 in the repository.
 
 - First, :ref:`learn how to print text <printing_text>`. This is important,

--- a/docs/pages/tutorials/repl.rst
+++ b/docs/pages/tutorials/repl.rst
@@ -337,5 +337,5 @@ interfaces.
 
 The End.
 
-.. _prompt_toolkit: https://github.com/prompt_toolkit/python-prompt-toolkit
+.. _prompt_toolkit: https://github.com/prompt-toolkit/python-prompt-toolkit
 .. _Pygments: http://pygments.org/


### PR DESCRIPTION
Just so I can have my egoboo quickly accessible from the docs ;).

The "contributors" link in the [thanks to](https://python-prompt-toolkit.readthedocs.io/en/master/index.html#thanks-to) section of the docs leads to 404. This PR fixes that.

Edit: I went and also fixed all of the other links that included `/prompt_toolkit/`. This means that this PR is a superset of #1367.