### PR TITLE
Docs: make sphinx autodoc generation platform agnostic

### DIFF
--- a/prompt_toolkit/eventloop/win32.py
+++ b/prompt_toolkit/eventloop/win32.py
@@ -1,4 +1,12 @@
-from ctypes import pointer, windll
+from ctypes import pointer
+
+from ..utils import SPHINX_AUTODOC_RUNNING
+
+# Do not import win32-specific stuff when generating documentation.
+# Otherwise RTD would be unable to generate docs for this module.
+if not SPHINX_AUTODOC_RUNNING:
+    from ctypes import windll
+
 from ctypes.wintypes import BOOL, DWORD, HANDLE
 from typing import List, Optional
 

--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -1,10 +1,18 @@
-import msvcrt
 import os
 import sys
 from abc import abstractmethod
 from asyncio import get_event_loop
 from contextlib import contextmanager
-from ctypes import pointer, windll
+
+from ..utils import SPHINX_AUTODOC_RUNNING
+
+# Do not import win32-specific stuff when generating documentation.
+# Otherwise RTD would be unable to generate docs for this module.
+if not SPHINX_AUTODOC_RUNNING:
+    import msvcrt
+    from ctypes import windll
+
+from ctypes import pointer
 from ctypes.wintypes import DWORD, HANDLE
 from typing import Callable, ContextManager, Dict, Iterable, List, Optional, TextIO
 

--- a/prompt_toolkit/output/win32.py
+++ b/prompt_toolkit/output/win32.py
@@ -1,14 +1,13 @@
 import os
-from ctypes import (
-    ArgumentError,
-    byref,
-    c_char,
-    c_long,
-    c_uint,
-    c_ulong,
-    pointer,
-    windll,
-)
+from ctypes import ArgumentError, byref, c_char, c_long, c_uint, c_ulong, pointer
+
+from ..utils import SPHINX_AUTODOC_RUNNING
+
+# Do not import win32-specific stuff when generating documentation.
+# Otherwise RTD would be unable to generate docs for this module.
+if not SPHINX_AUTODOC_RUNNING:
+    from ctypes import windll
+
 from ctypes.wintypes import DWORD, HANDLE
 from typing import Dict, List, Optional, TextIO, Tuple
 

--- a/prompt_toolkit/utils.py
+++ b/prompt_toolkit/utils.py
@@ -36,6 +36,10 @@ __all__ = [
     "is_dumb_terminal",
 ]
 
+# Used to ensure sphinx autodoc does not try to import platform-specific
+# stuff when documenting win32.py modules.
+SPHINX_AUTODOC_RUNNING = "sphinx.ext.autodoc" in sys.modules
+
 _Sender = TypeVar("_Sender", covariant=True)
 
 


### PR DESCRIPTION
Prevents imports of `ctypes.windll` and `msvcrt` when documentation is
being built. This is done by detecting the presence of `sphinx.ext.autodoc`.

---

Previously, this would've been the cause of the following warnings at the time of running `sphinx-build`:

```
WARNING: autodoc: failed to import module 'win32' from module 'prompt_toolkit.eventloop'; the following exception was raised:
cannot import name 'windll' from 'ctypes' (/home/mrmino/.pyenv/versions/3.9.1/lib/python3.9/ctypes/__init__.py)
WARNING: autodoc: failed to import module 'win32' from module 'prompt_toolkit.input'; the following exception was raised:
No module named 'msvcrt'
WARNING: autodoc: failed to import module 'win32' from module 'prompt_toolkit.output'; the following exception was raised:
cannot import name 'windll' from 'ctypes' (/home/mrmino/.pyenv/versions/3.9.1/lib/python3.9/ctypes/__init__.py)
```
---

I aired on the side of commenting it verbosely. Not sure if it isn't too much.