### PR TITLE
Docs: fix misspellings of CompletionsMenu

### DIFF
--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -751,7 +751,7 @@ class FloatContainer(Container):
                        floats=[
                            Float(xcursor=True,
                                 ycursor=True,
-                                content=CompletionMenu(...))
+                                content=CompletionsMenu(...))
                        ])
 
     :param z_index: (int or None) When specified, this can be used to bring

--- a/prompt_toolkit/layout/scrollable_pane.py
+++ b/prompt_toolkit/layout/scrollable_pane.py
@@ -29,7 +29,7 @@ class ScrollablePane(Container):
 
         If you want to display a completion menu for widgets in this
         `ScrollablePane`, then it's still a good practice to use a
-        `FloatContainer` with a `CompletionMenu` in a `Float` at the top-level
+        `FloatContainer` with a `CompletionsMenu` in a `Float` at the top-level
         of the layout hierarchy, rather then nesting a `FloatContainer` in this
         `ScrollablePane`. (Otherwise, it's possible that the completion menu
         is clipped.)


### PR DESCRIPTION
There's no such thing in the library as `CompletionMenu`. This PR substitutes misspellings of it for it's proper name: [`CompletionsMenu`](https://python-prompt-toolkit.readthedocs.io/en/master/pages/reference.html#prompt_toolkit.layout.CompletionsMenu).