### PR TITLE
feat: separate handling of Control-H (^H) and Backspace

### DIFF
--- a/prompt_toolkit/input/ansi_escape_sequences.py
+++ b/prompt_toolkit/input/ansi_escape_sequences.py
@@ -57,12 +57,11 @@ ANSI_SEQUENCES: Dict[str, Union[Keys, Tuple[Keys, ...]]] = {
     "\x1f": Keys.ControlUnderscore,  # Control-underscore (Also for Ctrl-hyphen.)
     # ASCII Delete (0x7f)
     # Vt220 (and Linux terminal) send this when pressing backspace. We map this
-    # to ControlH, because that will make it easier to create key bindings that
-    # work everywhere, with the trade-off that it's no longer possible to
-    # handle backspace and control-h individually for the few terminals that
-    # support it. (Most terminals send ControlH when backspace is pressed.)
+    # to Backspace, although that will make it harder to create key bindings that
+    # work everywhere given that some terminals don't support it
+    # (they send ControlH when backspace is pressed)
     # See: http://www.ibb.net/~anne/keyboard.html
-    "\x7f": Keys.ControlH,
+    "\x7f": Keys.Backspace,
     # --
     # Various
     "\x1b[1~": Keys.Home,  # tmux

--- a/prompt_toolkit/key_binding/bindings/basic.py
+++ b/prompt_toolkit/key_binding/bindings/basic.py
@@ -146,6 +146,9 @@ def load_basic_bindings() -> KeyBindings:
     handle("backspace", filter=insert_mode, save_before=if_no_repeat)(
         get_by_name("backward-delete-char")
     )
+    handle("c-h", filter=insert_mode, save_before=if_no_repeat)(
+        get_by_name("backward-delete-char")
+    )
     handle("delete", filter=insert_mode, save_before=if_no_repeat)(
         get_by_name("delete-char")
     )

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -76,6 +76,8 @@ class Keys(str, Enum):
     ControlCircumflex = "c-^"
     ControlUnderscore = "c-_"
 
+    Backspace = "backspace"
+
     Left = "left"
     Right = "right"
     Up = "up"
@@ -192,7 +194,6 @@ class Keys(str, Enum):
     ControlSpace = ControlAt
     Tab = ControlI
     Enter = ControlM
-    Backspace = ControlH
 
     # ShiftControl was renamed to ControlShift in
     # 888fcb6fa4efea0de8333177e1bbc792f3ff3c24 (20 Feb 2020).
@@ -207,7 +208,6 @@ ALL_KEYS: List[str] = [k.value for k in Keys]
 
 # Aliases.
 KEY_ALIASES: Dict[str, str] = {
-    "backspace": "c-h",
     "c-space": "c-@",
     "enter": "c-m",
     "tab": "c-i",


### PR DESCRIPTION
Allows achieving the console usability level of Windows :), where ^H and BS are already handled separately, e.g. with this patch you can bind `backward-kill-word` to Control-Backspace (which usually emits ^H) while leaving Backspace `backward-delete-char`

Per [this comment](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1380#issuecomment-786148973) this would be a breaking change, though a worthwile one

Closes the second part of #1380