### PR TITLE
SSH: Avoid leaking file descriptors

### DIFF
--- a/prompt_toolkit/contrib/ssh/server.py
+++ b/prompt_toolkit/contrib/ssh/server.py
@@ -95,6 +95,7 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):
             finally:
                 # Close the connection.
                 self._chan.close()
+                self._input.close()
 
     def terminal_size_changed(self, width, height, pixwidth, pixheight):
         # Send resize event to the current application.


### PR DESCRIPTION
The current implementation of [PromptToolkitSSHSession](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/06d28150801b9555a23a2addcf0cddd6e796ee62/prompt_toolkit/contrib/ssh/server.py#L18) leaks file descriptors because it does not close the `self._input` pipe. This can be demonstrated with the following test server:

```python
#!/usr/bin/env python3

import asyncio
import os

import asyncssh
from prompt_toolkit.contrib.ssh import PromptToolkitSSHServer
from prompt_toolkit.shortcuts import print_formatted_text


def get_open_fds():
    return len(os.listdir("/proc/self/fd/"))


async def interact(ssh_session):
    print_formatted_text("Number of open file descriptors: {}".format(get_open_fds()))


def main():
    port = 2345
    loop = asyncio.get_event_loop()
    loop.run_until_complete(
        asyncssh.create_server(
            lambda: PromptToolkitSSHServer(interact),
            "",
            port,
            server_host_keys=["./server_key"],
        )
    )
    loop.run_forever()


if __name__ == "__main__":
    main()
```

```shell
$ ssh localhost -p 2345
Number of open file descriptors: 12
Connection to localhost closed.
$ ssh localhost -p 2345
Number of open file descriptors: 14
Connection to localhost closed.
$ ssh localhost -p 2345
Number of open file descriptors: 16
Connection to localhost closed.
```

By doing `self._input.close()` before `self._interact` returns seems to fix the issue.