### PR TITLE
make the vt100 flush method re-entrant

### DIFF
--- a/prompt_toolkit/output/vt100.py
+++ b/prompt_toolkit/output/vt100.py
@@ -669,6 +669,7 @@ class Vt100_Output(Output):
             return
 
         data = "".join(self._buffer)
+        self._buffer = []
 
         try:
             # Ensure that `self.stdout` is made blocking when writing into it.
@@ -708,8 +709,6 @@ class Vt100_Output(Output):
                 pass
             else:
                 raise
-
-        self._buffer = []
 
     def ask_for_cpr(self) -> None:
         """


### PR DESCRIPTION
I use prompt toolkit with gevent, thanks to the super-useful[ aiogevent library](https://github.com/2mf/aiogevent)

I managed to get two times identical output, this is happening when `flush()` is called
whereas it is still executing - the solution to this is to make the `flush()` method re-entrant, by
reinitializing `self._buffer` just after data have been read from it, instead of emptying it at the
end of the method.