### PR TITLE
pyperclip: Fix pyperclip selection type

### DIFF
--- a/prompt_toolkit/clipboard/pyperclip.py
+++ b/prompt_toolkit/clipboard/pyperclip.py
@@ -38,5 +38,5 @@ class PyperclipClipboard(Clipboard):
         else:
             return ClipboardData(
                 text=text,
-                type=SelectionType.LINES if "\n" in text else SelectionType.LINES,
+                type=SelectionType.LINES if "\n" in text else SelectionType.CHARACTERS,
             )


### PR DESCRIPTION
Without this fix pasting single-line text always adds a newline