### PR TITLE
Use box drawing split characters for menu separators

### DIFF
--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -104,6 +104,8 @@ class Border:
     TOP_RIGHT = "\u2510"
     BOTTOM_LEFT = "\u2514"
     BOTTOM_RIGHT = "\u2518"
+    SPLIT_LEFT = "\u251c"
+    SPLIT_RIGHT = "\u2524"
 
 
 class TextArea:

--- a/prompt_toolkit/widgets/menus.py
+++ b/prompt_toolkit/widgets/menus.py
@@ -292,7 +292,14 @@ class MenuContainer:
                         else:
                             style = ""
 
-                        yield ("class:menu", Border.VERTICAL)
+
+                        if item.text == "-":
+                            yield (
+                                style + "class:menu-border",
+                                Border.SPLIT_LEFT,mouse_handler,
+                            )
+                        else:
+                            yield ("class:menu", Border.VERTICAL)
                         if item.text == "-":
                             yield (
                                 style + "class:menu-border",
@@ -309,11 +316,26 @@ class MenuContainer:
                         if item.children:
                             yield (style, ">", mouse_handler)
                         else:
-                            yield (style, " ", mouse_handler)
+                            if item.text == "-":
+                                yield (
+                                    style + "class:menu-border",
+                                    Border.HORIZONTAL,
+                                    mouse_handler,
+                                )
+                            else:
+                                yield (style, " ", mouse_handler)
 
                         if i == selected_item:
                             yield ("[SetMenuPosition]", "")
-                        yield ("class:menu", Border.VERTICAL)
+
+                        if item.text == "-":
+                            yield (
+                                style + "class:menu-border",
+                                Border.SPLIT_RIGHT,
+                                mouse_handler,
+                            )
+                        else:
+                            yield ("class:menu", Border.VERTICAL)
 
                         yield ("", "\n")
 


### PR DESCRIPTION
This PR adds extra box drawing characters for menu separators to make them look a bit nicer

![image](https://user-images.githubusercontent.com/12154190/117651559-fbea3c00-b189-11eb-99a4-f3d935678b41.png) ![image](https://user-images.githubusercontent.com/12154190/117651478-e4ab4e80-b189-11eb-81ac-eec8ef8442dd.png)

