### PR TITLE
Fix off-by-one error in FormattedTextControl mouse logic

### DIFF
--- a/prompt_toolkit/layout/controls.py
+++ b/prompt_toolkit/layout/controls.py
@@ -465,7 +465,7 @@ class FormattedTextControl(UIControl):
                 count = 0
                 for item in fragments:
                     count += len(item[1])
-                    if count >= xpos:
+                    if count > xpos:
                         if len(item) >= 3:
                             # Handler found. Call it.
                             # (Handler can return NotImplemented, so return


### PR DESCRIPTION
Example: if the first fragment in a line is, say, `('', 'hello', handler)`, then `count` is 5, and `handler` should apply when `xpos` is 0, 1, 2, 3, or 4, but *not* 5, i.e. `count` should be strictly greater than `xpos`.

(To me it "feels right" to write this as `xpos < count` instead, since it's normal to compare an index to a length with less-than, but that may be a matter of personal taste, so I've left it as it was.)