### PR TITLE
Instantiate a Buffer that does not use undo and redo stacks

### DIFF
--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -326,6 +326,8 @@ class PromptSession(Generic[_T]):
     :param input: `Input` object. (Note that the preferred way to change the
         input/output is by creating an `AppSession`.)
     :param output: `Output` object.
+    :param enable_undo_redo: :class:`~prompt_toolkit.filters.Filter` or `bool`. 
+        When False, undo and redo stacks will never get populated.
     """
 
     _fields = (
@@ -365,6 +367,7 @@ class PromptSession(Generic[_T]):
         "reserve_space_for_menu",
         "tempfile_suffix",
         "tempfile",
+        "enable_undo_redo",
     )
 
     def __init__(
@@ -410,6 +413,7 @@ class PromptSession(Generic[_T]):
         refresh_interval: float = 0,
         input: Optional[Input] = None,
         output: Optional[Output] = None,
+        enable_undo_redo: FilterOrBool = True,
     ) -> None:
 
         history = history or InMemoryHistory()
@@ -459,6 +463,7 @@ class PromptSession(Generic[_T]):
         self.reserve_space_for_menu = reserve_space_for_menu
         self.tempfile_suffix = tempfile_suffix
         self.tempfile = tempfile
+        self.enable_undo_redo = enable_undo_redo
 
         # Create buffers, layout and Application.
         self.history = history
@@ -520,6 +525,7 @@ class PromptSession(Generic[_T]):
             accept_handler=accept,
             tempfile_suffix=lambda: to_str(self.tempfile_suffix or ""),
             tempfile=lambda: to_str(self.tempfile or ""),
+            enable_undo_redo=self.enable_undo_redo
         )
 
     def _create_search_buffer(self) -> Buffer:


### PR DESCRIPTION
I have noticed that, under the current implementation, the undo stack gets appended a copy of the whole text at every new input, which results on unacceptable memory waste for my intended application, in which I plan to edit potentially large (up to 1MB) texts, and will handle undo/redo my own way.

My change simply consists in adding a `enable_undo_redo` parameter on the instantiation on `Buffer` and `PromptSession` (since it always creates its own internal buffer), and using it as a flag to prevent the stacks from being populated in `Buffer.undo`, `Buffer.redo` and `Buffer.save_to_undo_stack`.