### PR TITLE
 Hack to fix non-bmp unicode input for windows

### DIFF
--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -263,7 +263,7 @@ class ConsoleInputReader:
                 # Pasting: if the current key consists of text or \n, turn it
                 # into a BracketedPaste.
                 data = []
-                while k and (isinstance(k.key, str) or k.key == Keys.ControlJ):
+                while k and (not isinstance(k.key, Keys) or k.key == Keys.ControlJ):
                     data.append(k.data)
                     try:
                         k = next(gen)
@@ -359,7 +359,7 @@ class ConsoleInputReader:
         newline_count = 0
 
         for k in keys:
-            if isinstance(k.key, str):
+            if not isinstance(k.key, Keys):
                 text_count += 1
             if k.key == Keys.ControlM:
                 newline_count += 1

--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -320,6 +320,10 @@ class ConsoleInputReader:
 
     @staticmethod
     def _merge_paired_surrogates(key_presses: List[KeyPress]) -> Iterator[KeyPress]:
+        """
+        Combines consecutive KeyPresses with high and low surrogates into
+        single characters
+        """
         buffered_high_surrogate = None
         for key in key_presses:
             is_text = not isinstance(key.key, Keys)
@@ -328,6 +332,7 @@ class ConsoleInputReader:
 
             if buffered_high_surrogate:
                 if is_low_surrogate:
+                    # convert high surrogate + low surrogate to single character
                     fullchar = ((buffered_high_surrogate.key + key.key)
                         .encode('utf-16-le', 'surrogatepass')
                         .decode('utf-16-le'))


### PR DESCRIPTION
Fixes #1477. This transforms the list of decoded KeyPress events and merges surrogates into single Unicode characters.