### PR TITLE
Unicode windows fix

### DIFF
--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -263,7 +263,7 @@ class ConsoleInputReader:
                 # Pasting: if the current key consists of text or \n, turn it
                 # into a BracketedPaste.
                 data = []
-                while k and (isinstance(k.key, str) or k.key == Keys.ControlJ):
+                while k and (not isinstance(k.key, Keys) or k.key == Keys.ControlJ):
                     data.append(k.data)
                     try:
                         k = next(gen)
@@ -366,7 +366,7 @@ class ConsoleInputReader:
         newline_count = 0
 
         for k in keys:
-            if isinstance(k.key, str):
+            if not isinstance(k.key, Keys):
                 text_count += 1
             if k.key == Keys.ControlM:
                 newline_count += 1

--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -252,6 +252,9 @@ class ConsoleInputReader:
         # Fill in 'data' for key presses.
         all_keys = [self._insert_key_data(key) for key in all_keys]
 
+        # Correct non-bmp characters that are passed as separate surrogate codes
+        all_keys = list(self._merge_paired_surrogates(all_keys))
+
         if self.recognize_paste and self._is_paste(all_keys):
             gen = iter(all_keys)
             k: Optional[KeyPress]
@@ -316,6 +319,39 @@ class ConsoleInputReader:
                         yield key_press
 
     @staticmethod
+    def _merge_paired_surrogates(key_presses: List[KeyPress]) -> Iterator[KeyPress]:
+        """
+        Combines consecutive KeyPresses with high and low surrogates into
+        single characters
+        """
+        buffered_high_surrogate = None
+        for key in key_presses:
+            is_text = not isinstance(key.key, Keys)
+            is_high_surrogate = is_text and "\uD800" <= key.key <= "\uDBFF"
+            is_low_surrogate = is_text and "\uDC00" <= key.key <= "\uDFFF"
+
+            if buffered_high_surrogate:
+                if is_low_surrogate:
+                    # convert high surrogate + low surrogate to single character
+                    fullchar = (
+                        (buffered_high_surrogate.key + key.key)
+                        .encode("utf-16-le", "surrogatepass")
+                        .decode("utf-16-le")
+                    )
+                    key = KeyPress(fullchar, fullchar)
+                else:
+                    yield buffered_high_surrogate
+                buffered_high_surrogate = None
+
+            if is_high_surrogate:
+                buffered_high_surrogate = key
+            else:
+                yield key
+
+        if buffered_high_surrogate:
+            yield buffered_high_surrogate
+
+    @staticmethod
     def _is_paste(keys: List[KeyPress]) -> bool:
         """
         Return `True` when we should consider this list of keys as a paste
@@ -347,10 +383,11 @@ class ConsoleInputReader:
 
         control_key_state = ev.ControlKeyState
         u_char = ev.uChar.UnicodeChar
-        ascii_char = u_char.encode("utf-8")
+        # Use surrogatepass because u_char may be an unmatched surrogate
+        ascii_char = u_char.encode("utf-8", "surrogatepass")
 
-        # NOTE: We don't use `ev.uChar.AsciiChar`. That appears to be latin-1
-        #       encoded. See also:
+        # NOTE: We don't use `ev.uChar.AsciiChar`. That appears to be the
+        # unicode code point truncated to 1 byte. See also:
         # https://github.com/ipython/ipython/issues/10004
         # https://github.com/jonathanslenders/python-prompt-toolkit/issues/389
 


### PR DESCRIPTION
Same as https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1478
But squashed and applied "black".