### PR TITLE
Update to Sphinx 4.1.2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+version: 2
+
+formats:
+  - pdf
+  - epub
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ import sys
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.graphviz"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+# templates_path = ["_templates"]
 
 # The suffix of source filenames.
 source_suffix = ".rst"
@@ -139,7 +139,7 @@ html_logo = "images/logo_400px.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==4.1.2
+wcwidth==0.2.5
+pyperclip==1.8.2


### PR DESCRIPTION
It looks as though the current Sphinx version is quite old. In particular, the [`objecst.inv`](https://python-prompt-toolkit.readthedocs.io/en/master/objects.inv) file currently generated for this project seems to be missing some objects.

In this PR, I have upgraded Sphinx to version 4.1.2. There did not appear to be any issues caused by doing this. This resolves the aforementioned problem with `objects.inv`.

I have put a test rendering of the documentation [here](https://prompt-toolkit-test.readthedocs.io/en/upgrade-sphinx/index.html), so you can also check that nothing has regressed.