### PR TITLE
Fix bug preventing documentation search from working in some cases.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==4.1.2
 wcwidth==0.2.5
 pyperclip==1.8.2
+sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
In some cases, the documentation search does not work. This issue was introduced in 279720474de378d6a970efc0858b595d798c5163 when Sphinx was upgraded. The relevant issue is:

 - https://github.com/sphinx-doc/sphinx/issues/8623

For some reason, the `sphinx_rtd_theme` theme used for this project is constrained to `<0.5` (not sure where this has been set). This PR forces the version of `sphinx_rtd_theme` to a working version (haven't actually been able to test as I don't know how to recreate the `<0.5` constraint).