### PR TITLE
Add wrapper function for get_event_loop

### DIFF
--- a/examples/ssh/asyncssh-server.py
+++ b/examples/ssh/asyncssh-server.py
@@ -10,6 +10,7 @@ from pygments.lexers.html import HtmlLexer
 
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.contrib.ssh import PromptToolkitSSHServer, PromptToolkitSSHSession
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.shortcuts import ProgressBar, print_formatted_text
 from prompt_toolkit.shortcuts.dialogs import input_dialog, yes_no_dialog
@@ -105,7 +106,7 @@ def main(port=8222):
     logging.basicConfig()
     logging.getLogger().setLevel(logging.DEBUG)
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     loop.run_until_complete(
         asyncssh.create_server(
             lambda: PromptToolkitSSHServer(interact),

--- a/examples/telnet/chat-app.py
+++ b/examples/telnet/chat-app.py
@@ -6,9 +6,9 @@ each other.
 """
 import logging
 import random
-from asyncio import get_event_loop
 
 from prompt_toolkit.contrib.telnet.server import TelnetServer
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.shortcuts import PromptSession, clear, prompt
 

--- a/examples/telnet/dialog.py
+++ b/examples/telnet/dialog.py
@@ -3,9 +3,9 @@
 Example of a telnet application that displays a dialog window.
 """
 import logging
-from asyncio import get_event_loop
 
 from prompt_toolkit.contrib.telnet.server import TelnetServer
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.shortcuts.dialogs import yes_no_dialog
 
 # Set up logging

--- a/examples/telnet/hello-world.py
+++ b/examples/telnet/hello-world.py
@@ -7,9 +7,9 @@ Also see the `hello-world-asyncio.py` example which uses an asyncio coroutine.
 That is probably the preferred way if you only need Python 3 support.
 """
 import logging
-from asyncio import get_event_loop
 
 from prompt_toolkit.contrib.telnet.server import TelnetServer
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.shortcuts import clear, prompt
 
 # Set up logging

--- a/examples/telnet/toolbar.py
+++ b/examples/telnet/toolbar.py
@@ -4,10 +4,10 @@ Example of a telnet application that displays a bottom toolbar and completions
 in the prompt.
 """
 import logging
-from asyncio import get_event_loop
 
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.contrib.telnet.server import TelnetServer
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.shortcuts import PromptSession
 
 # Set up logging

--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -11,7 +11,6 @@ from asyncio import (
     Future,
     Task,
     ensure_future,
-    get_event_loop,
     new_event_loop,
     set_event_loop,
     sleep,
@@ -48,7 +47,7 @@ from prompt_toolkit.eventloop import (
     get_traceback_from_context,
     run_in_executor_with_context,
 )
-from prompt_toolkit.eventloop.utils import call_soon_threadsafe
+from prompt_toolkit.eventloop.utils import call_soon_threadsafe, get_event_loop
 from prompt_toolkit.filters import Condition, Filter, FilterOrBool, to_filter
 from prompt_toolkit.formatted_text import AnyFormattedText
 from prompt_toolkit.input.base import Input
@@ -1366,7 +1365,7 @@ def attach_winch_signal_handler(
 
     # Keep track of the previous handler.
     # (Only UnixSelectorEventloop has `_signal_handlers`.)
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     previous_winch_handler = getattr(loop, "_signal_handlers", {}).get(sigwinch)
 
     try:

--- a/prompt_toolkit/contrib/ssh/server.py
+++ b/prompt_toolkit/contrib/ssh/server.py
@@ -9,6 +9,7 @@ import asyncssh
 
 from prompt_toolkit.application.current import AppSession, create_app_session
 from prompt_toolkit.data_structures import Size
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output.vt100 import Vt100_Output
 
@@ -70,7 +71,7 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
         return True
 
     def session_started(self) -> None:
-        self.interact_task = asyncio.get_event_loop().create_task(self._interact())
+        self.interact_task = get_event_loop().create_task(self._interact())
 
     async def _interact(self) -> None:
         if self._chan is None:

--- a/prompt_toolkit/contrib/telnet/server.py
+++ b/prompt_toolkit/contrib/telnet/server.py
@@ -4,12 +4,12 @@ Telnet server.
 import asyncio
 import contextvars  # Requires Python3.7!
 import socket
-from asyncio import get_event_loop
 from typing import Awaitable, Callable, List, Optional, Set, TextIO, Tuple, cast
 
 from prompt_toolkit.application.current import create_app_session, get_app
 from prompt_toolkit.application.run_in_terminal import run_in_terminal
 from prompt_toolkit.data_structures import Size
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.formatted_text import AnyFormattedText, to_formatted_text
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output.vt100 import Vt100_Output

--- a/prompt_toolkit/eventloop/__init__.py
+++ b/prompt_toolkit/eventloop/__init__.py
@@ -7,6 +7,7 @@ from .inputhook import (
 )
 from .utils import (
     call_soon_threadsafe,
+    get_event_loop,
     get_traceback_from_context,
     run_in_executor_with_context,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "run_in_executor_with_context",
     "call_soon_threadsafe",
     "get_traceback_from_context",
+    "get_event_loop",
     # Inputhooks.
     "new_eventloop_with_inputhook",
     "set_eventloop_with_inputhook",

--- a/prompt_toolkit/eventloop/async_generator.py
+++ b/prompt_toolkit/eventloop/async_generator.py
@@ -1,10 +1,10 @@
 """
 Implementation for async generators.
 """
-from asyncio import Queue, get_event_loop
+from asyncio import Queue
 from typing import AsyncGenerator, Callable, Iterable, TypeVar, Union
 
-from .utils import run_in_executor_with_context
+from .utils import run_in_executor_with_context, get_event_loop
 
 __all__ = [
     "generator_to_async_generator",

--- a/prompt_toolkit/eventloop/inputhook.py
+++ b/prompt_toolkit/eventloop/inputhook.py
@@ -27,7 +27,7 @@ import os
 import select
 import selectors
 import threading
-from asyncio import AbstractEventLoop, get_event_loop
+from asyncio import AbstractEventLoop
 from selectors import BaseSelector, SelectorKey
 from typing import (
     TYPE_CHECKING,
@@ -40,6 +40,7 @@ from typing import (
     Tuple,
 )
 
+from .utils import get_event_loop
 from prompt_toolkit.utils import is_windows
 
 __all__ = [

--- a/prompt_toolkit/eventloop/utils.py
+++ b/prompt_toolkit/eventloop/utils.py
@@ -100,7 +100,8 @@ def get_traceback_from_context(context: Dict[str, Any]) -> Optional[TracebackTyp
 
     return None
 
-def get_event_loop():
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
     """Backward compatible way to get the event loop"""
     # Python 3.6 doesn't have get_running_loop
     # Python 3.10 deprecated get_event_loop

--- a/prompt_toolkit/eventloop/utils.py
+++ b/prompt_toolkit/eventloop/utils.py
@@ -1,6 +1,6 @@
+import asyncio
 import sys
 import time
-from asyncio import AbstractEventLoop, get_event_loop
 from types import TracebackType
 from typing import Any, Awaitable, Callable, Dict, Optional, TypeVar, cast
 
@@ -13,13 +13,14 @@ __all__ = [
     "run_in_executor_with_context",
     "call_soon_threadsafe",
     "get_traceback_from_context",
+    "get_event_loop",
 ]
 
 _T = TypeVar("_T")
 
 
 def run_in_executor_with_context(
-    func: Callable[..., _T], *args: Any, loop: Optional[AbstractEventLoop] = None
+    func: Callable[..., _T], *args: Any, loop: Optional[asyncio.AbstractEventLoop] = None
 ) -> Awaitable[_T]:
     """
     Run a function in an executor, but make sure it uses the same contextvars.
@@ -36,7 +37,7 @@ def run_in_executor_with_context(
 def call_soon_threadsafe(
     func: Callable[[], None],
     max_postpone_time: Optional[float] = None,
-    loop: Optional[AbstractEventLoop] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> None:
     """
     Wrapper around asyncio's `call_soon_threadsafe`.
@@ -98,3 +99,17 @@ def get_traceback_from_context(context: Dict[str, Any]) -> Optional[TracebackTyp
             return sys.exc_info()[2]
 
     return None
+
+def get_event_loop():
+    """Backward compatible way to get the event loop"""
+    # Python 3.6 doesn't have get_running_loop
+    # Python 3.10 deprecated get_event_loop
+    try:
+        getloop = asyncio.get_running_loop
+    except AttributeError:
+        getloop = asyncio.get_event_loop
+
+    try:
+        return getloop()
+    except RuntimeError:
+        return asyncio.get_event_loop_policy().get_event_loop()

--- a/prompt_toolkit/history.py
+++ b/prompt_toolkit/history.py
@@ -7,12 +7,13 @@ NOTE: There is no `DynamicHistory`:
       loading can be done asynchronously and making the history swappable would
       probably break this.
 """
-import asyncio
 import datetime
 import os
 import threading
 from abc import ABCMeta, abstractmethod
 from typing import AsyncGenerator, Iterable, List, Optional, Sequence, Tuple
+
+from prompt_toolkit.eventloop import get_event_loop
 
 __all__ = [
     "History",
@@ -134,7 +135,7 @@ class ThreadedHistory(History):
             self._load_thread.start()
 
         # Consume the `_loaded_strings` list, using asyncio.
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
 
         # Create threading Event so that we can wait for new items.
         event = threading.Event()

--- a/prompt_toolkit/input/vt100.py
+++ b/prompt_toolkit/input/vt100.py
@@ -3,7 +3,7 @@ import io
 import sys
 import termios
 import tty
-from asyncio import AbstractEventLoop, get_event_loop
+from asyncio import AbstractEventLoop
 from typing import (
     Callable,
     ContextManager,
@@ -17,6 +17,7 @@ from typing import (
     Union,
 )
 
+from prompt_toolkit.eventloop import get_event_loop
 from ..key_binding import KeyPress
 from .base import Input
 from .posix_utils import PosixStdinReader

--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -1,10 +1,10 @@
 import os
 import sys
 from abc import abstractmethod
-from asyncio import get_event_loop
 from contextlib import contextmanager
 
 from ..utils import SPHINX_AUTODOC_RUNNING
+from prompt_toolkit.eventloop import get_event_loop
 
 # Do not import win32-specific stuff when generating documentation.
 # Otherwise RTD would be unable to generate docs for this module.

--- a/prompt_toolkit/shortcuts/dialogs.py
+++ b/prompt_toolkit/shortcuts/dialogs.py
@@ -1,12 +1,11 @@
 import functools
-from asyncio import get_event_loop
 from typing import Any, Callable, List, Optional, Tuple, TypeVar
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import Completer
-from prompt_toolkit.eventloop import run_in_executor_with_context
+from prompt_toolkit.eventloop import get_event_loop, run_in_executor_with_context
 from prompt_toolkit.filters import FilterOrBool
 from prompt_toolkit.formatted_text import AnyFormattedText
 from prompt_toolkit.key_binding.bindings.focus import focus_next, focus_previous

--- a/prompt_toolkit/shortcuts/progress_bar/base.py
+++ b/prompt_toolkit/shortcuts/progress_bar/base.py
@@ -13,7 +13,7 @@ import os
 import signal
 import threading
 import traceback
-from asyncio import get_event_loop, new_event_loop, set_event_loop
+from asyncio import new_event_loop, set_event_loop
 from typing import (
     Generic,
     Iterable,
@@ -29,6 +29,7 @@ from typing import (
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app_session
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.filters import Condition, is_done, renderer_height_is_known
 from prompt_toolkit.formatted_text import (
     AnyFormattedText,

--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -24,7 +24,6 @@ Example::
         s = PromptSession()
         result = s.prompt('Say something: ')
 """
-from asyncio import get_event_loop
 from contextlib import contextmanager
 from enum import Enum
 from functools import partial
@@ -48,6 +47,7 @@ from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.clipboard import Clipboard, DynamicClipboard, InMemoryClipboard
 from prompt_toolkit.completion import Completer, DynamicCompleter, ThreadedCompleter
 from prompt_toolkit.document import Document
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER, EditingMode
 from prompt_toolkit.filters import (
     Condition,

--- a/prompt_toolkit/shortcuts/utils.py
+++ b/prompt_toolkit/shortcuts/utils.py
@@ -1,10 +1,10 @@
-from asyncio import get_event_loop
 from asyncio.events import AbstractEventLoop
 from typing import TYPE_CHECKING, Any, Optional, TextIO
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app_or_none, get_app_session
 from prompt_toolkit.application.run_in_terminal import run_in_terminal
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.formatted_text import (
     FormattedText,
     StyleAndTextTuples,

--- a/tests/test_async_generator.py
+++ b/tests/test_async_generator.py
@@ -1,6 +1,4 @@
-from asyncio import get_event_loop
-
-from prompt_toolkit.eventloop import generator_to_async_generator
+from prompt_toolkit.eventloop import generator_to_async_generator, get_event_loop
 
 
 def _sync_generator():

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,5 +1,4 @@
-import asyncio
-
+from prompt_toolkit.eventloop import get_event_loop
 from prompt_toolkit.history import FileHistory, InMemoryHistory, ThreadedHistory
 
 
@@ -13,7 +12,7 @@ def _call_history_load(history):
         async for item in history.load():
             result.append(item)
 
-    asyncio.get_event_loop().run_until_complete(call_load())
+    get_event_loop().run_until_complete(call_load())
     return result
 
 


### PR DESCRIPTION
- Project still supports Py3.6
- asyncio.get_event_loop is deprecated in Py3.10
- Add wrapper function in eventloop utils to account for this

All the `tox` tests pass, however as this is my first contribution to this project I would appreciate a double check that this is not a breaking change.