### PR TITLE
Add support for some CSI 27 modified variants of Enter

### DIFF
--- a/prompt_toolkit/input/ansi_escape_sequences.py
+++ b/prompt_toolkit/input/ansi_escape_sequences.py
@@ -121,6 +121,14 @@ ANSI_SEQUENCES: Dict[str, Union[Keys, Tuple[Keys, ...]]] = {
     "\x1b[23;2~": Keys.F23,
     "\x1b[24;2~": Keys.F24,
     # --
+    # CSI 27 disambiguated modified "other" keys (xterm)
+    # Ref: https://invisible-island.net/xterm/modified-keys.html
+    # These are currently unsupported, so just re-map some common ones to the
+    # unmodified versions
+    "\x1b[27;2;13~": Keys.ControlM,  # Shift + Enter
+    "\x1b[27;5;13~": Keys.ControlM,  # Ctrl + Enter
+    "\x1b[27;6;13~": Keys.ControlM,  # Ctrl + Shift + Enter
+    # --
     # Control + function keys.
     "\x1b[1;5P": Keys.ControlF1,
     "\x1b[1;5Q": Keys.ControlF2,


### PR DESCRIPTION
xterm has 3 different disambiguated key modes intended to be used by applications that wish to distinguish keyboard modifiers for certain keypresses. These emit CSI 27 escapes with a modifiers bitmask field, and may be enabled by configuration.

We can't parse these properly, so just add support for a few common modified variants of Enter in the escape sequence list. These variants previously had no distinct encoding, so the CSI variants have been adopted by some other terms, namely foot.
