### PR TITLE
Fix multiline bracketed paste on Windows

### DIFF
--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -271,7 +271,7 @@ class ConsoleInputReader:
                 # Pasting: if the current key consists of text or \n, turn it
                 # into a BracketedPaste.
                 data = []
-                while k and (not isinstance(k.key, Keys) or k.key == Keys.ControlJ):
+                while k and (not isinstance(k.key, Keys) or k.key in {Keys.ControlJ, Keys.ControlM}):
                     data.append(k.data)
                     try:
                         k = next(gen)
@@ -379,7 +379,7 @@ class ConsoleInputReader:
             if k.key == Keys.ControlM:
                 newline_count += 1
 
-        return newline_count >= 1 and text_count > 1
+        return newline_count >= 1 and text_count >= 1
 
     def _event_to_key_presses(self, ev: KEY_EVENT_RECORD) -> List[KeyPress]:
         """

--- a/prompt_toolkit/input/win32.py
+++ b/prompt_toolkit/input/win32.py
@@ -271,7 +271,10 @@ class ConsoleInputReader:
                 # Pasting: if the current key consists of text or \n, turn it
                 # into a BracketedPaste.
                 data = []
-                while k and (not isinstance(k.key, Keys) or k.key in {Keys.ControlJ, Keys.ControlM}):
+                while k and (
+                    not isinstance(k.key, Keys)
+                    or k.key in {Keys.ControlJ, Keys.ControlM}
+                ):
                     data.append(k.data)
                     try:
                         k = next(gen)


### PR DESCRIPTION
- `Keys.ControlM` should not break paste content into multiple bracketed pastes.
- Update code of `ConsoleInputReader._is_paste` to match its comment: Consider paste when it contains at least one newline and at least one other character.

This fixes #1519.