### PR TITLE
Capture cancellation exceptions upon stopping the Telnet server

### DIFF
--- a/prompt_toolkit/contrib/telnet/server.py
+++ b/prompt_toolkit/contrib/telnet/server.py
@@ -316,7 +316,10 @@ class TelnetServer:
             t.cancel()
 
         for t in self._application_tasks:
-            await t
+            try:
+                await t
+            except asyncio.CancelledError:
+                logger.debug("Task %s cancelled", str(t))
 
     def _accept(self) -> None:
         """


### PR DESCRIPTION
Here is PR with changes about capturing cancellation exceptions upon stopping the `TelnetServer`.