### PR TITLE
Prevent window contents overflowing

### DIFF
--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -2059,7 +2059,7 @@ class Window(Container):
                             return x, y  # Break out of all for loops.
 
                     # Set character in screen and shift 'x'.
-                    if x >= 0 and y >= 0 and x < write_position.width:
+                    if x >= 0 and y >= 0 and x < width:
                         new_buffer_row[x + xpos] = char
 
                         # When we print a multi width character, make sure


### PR DESCRIPTION
This PR fixes a bug where a window's contents overflow the boundary of the window when margins are used.

The issue occurs because when the window body is copied to the new screen object, the width of the content which is copied is limited by `write_position.width` rather than the `width` parameter: only the latter takes into account window margins.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/12154190/143875919-11048a5e-bf94-4de5-b458-bfdbbff6ad84.png) | ![image](https://user-images.githubusercontent.com/12154190/143875970-99ceeb57-50ff-4822-9184-c70c02b295f9.png) |


<details>
  <summary>This is the sample code demonstrating this bug shown in the screenshots above</summary>

```python
from prompt_toolkit import Application
from prompt_toolkit.key_binding import KeyBindings
from prompt_toolkit.layout.layout import Layout
from prompt_toolkit.layout.containers import HSplit, VSplit
from prompt_toolkit.widgets import Frame, TextArea
from prompt_toolkit.key_binding.bindings.focus import focus_next

kb = KeyBindings()

@kb.add('c-q')
def exit_(event):
    event.app.exit()

kb.add('tab')(focus_next)

root_container = VSplit([
    HSplit([
        Frame(
            TextArea(
                text='\n'.join(['abcedfghijklmnop']*3),
                wrap_lines=False,
                line_numbers=True,
                width=10,
                height=3,
            ),
        ),
        Frame(
            TextArea(
                text='\n'.join(['abcedfghijklmnop']*3),
                wrap_lines=False,
                line_numbers=False,
                width=10,
                height=3,
            ),
        ),
    ]),
])

layout = Layout(root_container)

app = Application(layout=layout, key_bindings=kb, full_screen=True)
app.run()
```
</details>
