### PR TITLE
Fix mypy errors

### DIFF
--- a/prompt_toolkit/application/application.py
+++ b/prompt_toolkit/application/application.py
@@ -1156,15 +1156,16 @@ class Application(Generic[_AppResult]):
         if _SIGTSTP is not None:
 
             def run() -> None:
+                signal = cast(int, _SIGTSTP)
                 # Send `SIGTSTP` to own process.
                 # This will cause it to suspend.
 
                 # Usually we want the whole process group to be suspended. This
                 # handles the case when input is piped from another process.
                 if suspend_group:
-                    os.kill(0, _SIGTSTP)
+                    os.kill(0, signal)
                 else:
-                    os.kill(os.getpid(), _SIGTSTP)
+                    os.kill(os.getpid(), signal)
 
             run_in_terminal(run)
 

--- a/prompt_toolkit/layout/utils.py
+++ b/prompt_toolkit/layout/utils.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Iterable, List, TypeVar, Union, cast, overload
+
 from typing_extensions import SupportsIndex
 
 from prompt_toolkit.formatted_text.base import OneStyleAndTextTuple

--- a/prompt_toolkit/layout/utils.py
+++ b/prompt_toolkit/layout/utils.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Iterable, List, TypeVar, Union, cast, overload
 
-from typing_extensions import SupportsIndex
-
 from prompt_toolkit.formatted_text.base import OneStyleAndTextTuple
 
 if TYPE_CHECKING:

--- a/prompt_toolkit/layout/utils.py
+++ b/prompt_toolkit/layout/utils.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Iterable, List, TypeVar, Union, cast, overload
+from typing_extensions import SupportsIndex
 
 from prompt_toolkit.formatted_text.base import OneStyleAndTextTuple
 
@@ -28,7 +29,7 @@ class _ExplodedList(List[_T]):
     def extend(self, lst: Iterable[_T]) -> None:
         super().extend(explode_text_fragments(lst))
 
-    def insert(self, index: int, item: _T) -> None:
+    def insert(self, index: SupportsIndex, item: _T) -> None:
         raise NotImplementedError  # TODO
 
     # TODO: When creating a copy() or [:], return also an _ExplodedList.

--- a/prompt_toolkit/layout/utils.py
+++ b/prompt_toolkit/layout/utils.py
@@ -28,7 +28,7 @@ class _ExplodedList(List[_T]):
     def extend(self, lst: Iterable[_T]) -> None:
         super().extend(explode_text_fragments(lst))
 
-    def insert(self, index: SupportsIndex, item: _T) -> None:
+    def insert(self, index: "SupportsIndex", item: _T) -> None:
         raise NotImplementedError  # TODO
 
     # TODO: When creating a copy() or [:], return also an _ExplodedList.


### PR DESCRIPTION
Current version has errors:

mypy prompt_toolkit:

```
prompt_toolkit/layout/utils.py:31: error: Argument 1 of "insert" is incompatible with supertype "list"; supertype defines the argument type as "SupportsIndex"
prompt_toolkit/layout/utils.py:31: note: This violates the Liskov substitution principle
prompt_toolkit/layout/utils.py:31: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
prompt_toolkit/application/application.py:1165: error: Argument 2 to "kill" has incompatible type "Optional[Any]"; expected "int"
prompt_toolkit/application/application.py:1167: error: Argument 2 to "kill" has incompatible type "Optional[Any]"; expected "int"
Found 3 errors in 2 files (checked 143 source files)
```