### PR TITLE
Increase slow_duration_callback

### DIFF
--- a/prompt_toolkit/application/dummy.py
+++ b/prompt_toolkit/application/dummy.py
@@ -34,6 +34,7 @@ class DummyApplication(Application[None]):
         pre_run: Optional[Callable[[], None]] = None,
         set_exception_handler: bool = True,
         handle_sigint: bool = True,
+        slow_callback_duration: float = 0.5,
     ) -> None:
         raise NotImplementedError("A DummyApplication is not supposed to run.")
 


### PR DESCRIPTION
This prevents printing warnings if rendering takes too long on slow systems.