### PR TITLE
add default values option for Dialog

### DIFF
--- a/prompt_toolkit/shortcuts/dialogs.py
+++ b/prompt_toolkit/shortcuts/dialogs.py
@@ -175,6 +175,7 @@ def radiolist_dialog(
     ok_text: str = "Ok",
     cancel_text: str = "Cancel",
     values: Optional[List[Tuple[_T, AnyFormattedText]]] = None,
+    default_values :List[_T] = [],
     style: Optional[BaseStyle] = None,
 ) -> Application[_T]:
     """
@@ -189,7 +190,7 @@ def radiolist_dialog(
     def ok_handler() -> None:
         get_app().exit(result=radio_list.current_value)
 
-    radio_list = RadioList(values)
+    radio_list = RadioList(values=values, default_values = default_values)
 
     dialog = Dialog(
         title=title,
@@ -213,6 +214,7 @@ def checkboxlist_dialog(
     ok_text: str = "Ok",
     cancel_text: str = "Cancel",
     values: Optional[List[Tuple[_T, AnyFormattedText]]] = None,
+    default_values: List[_T] = [],
     style: Optional[BaseStyle] = None,
 ) -> Application[List[_T]]:
     """
@@ -227,7 +229,7 @@ def checkboxlist_dialog(
     def ok_handler() -> None:
         get_app().exit(result=cb_list.current_values)
 
-    cb_list = CheckboxList(values)
+    cb_list = CheckboxList(values = values, default_values = default_values)
 
     dialog = Dialog(
         title=title,

--- a/prompt_toolkit/shortcuts/dialogs.py
+++ b/prompt_toolkit/shortcuts/dialogs.py
@@ -175,7 +175,7 @@ def radiolist_dialog(
     ok_text: str = "Ok",
     cancel_text: str = "Cancel",
     values: Optional[List[Tuple[_T, AnyFormattedText]]] = None,
-    default_values :List[_T] = [],
+    default_values: List[_T] = [],
     style: Optional[BaseStyle] = None,
 ) -> Application[_T]:
     """
@@ -190,7 +190,7 @@ def radiolist_dialog(
     def ok_handler() -> None:
         get_app().exit(result=radio_list.current_value)
 
-    radio_list = RadioList(values=values, default_values = default_values)
+    radio_list = RadioList(values=values, default_values=default_values)
 
     dialog = Dialog(
         title=title,
@@ -229,7 +229,7 @@ def checkboxlist_dialog(
     def ok_handler() -> None:
         get_app().exit(result=cb_list.current_values)
 
-    cb_list = CheckboxList(values = values, default_values = default_values)
+    cb_list = CheckboxList(values=values, default_values=default_values)
 
     dialog = Dialog(
         title=title,

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -872,7 +872,8 @@ class Checkbox(CheckboxList[str]):
 
     def __init__(self, text: AnyFormattedText = "", checked: bool = False) -> None:
         values = [("value", text)]
-        CheckboxList.__init__(self, values)
+        default_values = ["value"]
+        CheckboxList.__init__(self, values=values, default_values=default_values)
         self.checked = checked
 
     @property

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -697,13 +697,13 @@ class _DialogList(Generic[_T]):
         # current_values will be used in multiple_selection,
         # current_value will be used otherwise.
         candidate: List[_T] = [value for (value, _) in values]
-        self.current_values: List[_T] = [ 
+        self.current_values: List[_T] = [
             default_value
             for default_value in default_values
             if (default_value in candidate)
         ]
         self.current_value: _T = (
-            default_values[0] 
+            default_values[0]
             if len(default_values) and default_values[0] in candidate
             else values[0][0]
         )

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -686,14 +686,27 @@ class _DialogList(Generic[_T]):
     multiple_selection: bool = False
     show_scrollbar: bool = True
 
-    def __init__(self, values: Sequence[Tuple[_T, AnyFormattedText]]) -> None:
+    def __init__(
+        self,
+        values: Sequence[Tuple[_T, AnyFormattedText]],
+        default_values: List[_T]
+    ) -> None:
         assert len(values) > 0
 
         self.values = values
         # current_values will be used in multiple_selection,
         # current_value will be used otherwise.
-        self.current_values: List[_T] = []
-        self.current_value: _T = values[0][0]
+        candidate: List[_T] = [value for (value, _) in values]
+        self.current_values: List[_T] = [ 
+            default_value
+            for default_value in default_values
+            if (default_value in candidate)
+        ]
+        self.current_value: _T = (
+            default_values[0] 
+            if len(default_values) and default_values[0] in candidate
+            else values[0][0]
+        )
         self._selected_index = 0
 
         # Key bindings.

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -687,9 +687,7 @@ class _DialogList(Generic[_T]):
     show_scrollbar: bool = True
 
     def __init__(
-        self,
-        values: Sequence[Tuple[_T, AnyFormattedText]],
-        default_values: List[_T]
+        self, values: Sequence[Tuple[_T, AnyFormattedText]], default_values: List[_T]
     ) -> None:
         assert len(values) > 0
 


### PR DESCRIPTION
Hello, I'm happy to post here.

## Why
Default Value settings are important for some people (includes me).

## What
I add an option to set default value for Dialogs(Checkbox list dialog and Radio list dialog).

- It can check whether the value is valid or invalid.
  - later checkbox example, "banana" is not a valid option, so it is removed. "eggs" and "croissants" are selected.

## Usage
### Checkbox list dialog
```
results_array = checkboxlist_dialog(
    title="CheckboxList dialog",
    text="What would you like in your breakfast ?",
    values=[
        ("eggs", "Eggs"),
        ("bacon", "Bacon"),
        ("croissants", "20 Croissants"),
        ("daily", "The breakfast of the day")
    ],
    default_values=["banana", "eggs", "croissants"]
).run()
All values in default_values will be used for default value.
```
### Radio list dialog
```
result = radiolist_dialog(
    values=[
        ("red", "Red"),
        ("green", "Green"),
        ("blue", "Blue"),
        ("orange", "Orange"),
    ],
    default_values=["blue"],
    title="Radiolist dialog example",
    text="Please select a color:",
).run()
```
First index (default_values[0], in this case "blue") item will be used for default value.

## How It Works
### checkbox dialogs
I set default_values as `["banana", "eggs", "croissants"]`
![checkbox](https://user-images.githubusercontent.com/11750226/152786572-8ffb7f99-6386-46ab-89ef-9a743886824c.gif)
  
### radio dialogs
I set default_values as `["blue"]`
"blue" is selected.  
![radio](https://user-images.githubusercontent.com/11750226/152786108-dc3e78f4-8047-4d58-9e73-af8a66c03be4.gif)

## Related
- issue
    - #1544 
- PR
    - #651

Thank you.