### PR TITLE
HTML.format specifiers

### DIFF
--- a/prompt_toolkit/formatted_text/html.py
+++ b/prompt_toolkit/formatted_text/html.py
@@ -1,6 +1,6 @@
 import xml.dom.minidom as minidom
-from typing import Any, List, Tuple, Union
 from string import Formatter
+from typing import Any, List, Tuple, Union
 
 from .base import FormattedText, StyleAndTextTuples
 
@@ -122,7 +122,7 @@ class HTML:
 
 
 class HTMLFormatter(Formatter):
-    def format_field(self, value, format_spec):
+    def format_field(self, value: object, format_spec: str) -> str:
         return html_escape(format(value, format_spec))
 
 

--- a/prompt_toolkit/formatted_text/html.py
+++ b/prompt_toolkit/formatted_text/html.py
@@ -1,5 +1,6 @@
 import xml.dom.minidom as minidom
 from typing import Any, List, Tuple, Union
+from string import Formatter
 
 from .base import FormattedText, StyleAndTextTuples
 
@@ -107,11 +108,7 @@ class HTML:
         Like `str.format`, but make sure that the arguments are properly
         escaped.
         """
-        # Escape all the arguments.
-        escaped_args = [html_escape(a) for a in args]
-        escaped_kwargs = {k: html_escape(v) for k, v in kwargs.items()}
-
-        return HTML(self.value.format(*escaped_args, **escaped_kwargs))
+        return HTML(FORMATTER.vformat(self.value, args, kwargs))
 
     def __mod__(self, value: Union[object, Tuple[object, ...]]) -> "HTML":
         """
@@ -122,6 +119,11 @@ class HTML:
 
         value = tuple(html_escape(i) for i in value)
         return HTML(self.value % value)
+
+
+class HTMLFormatter(Formatter):
+    def format_field(self, value, format_spec):
+        return html_escape(format(value, format_spec))
 
 
 def html_escape(text: object) -> str:
@@ -136,3 +138,6 @@ def html_escape(text: object) -> str:
         .replace(">", "&gt;")
         .replace('"', "&quot;")
     )
+
+
+FORMATTER = HTMLFormatter()

--- a/tests/test_formatted_text.py
+++ b/tests/test_formatted_text.py
@@ -141,8 +141,8 @@ def test_html_interpolation():
     value = HTML("<b>{a}</b><u>{b}</u>").format(a="hello", b="world")
     assert to_formatted_text(value) == [("class:b", "hello"), ("class:u", "world")]
 
-    value = HTML("<b>{:d}</b><u>{:f}</u>").format(3, 3.14)
-    assert to_formatted_text(value) == [("class:b", "3"), ("class:u", "3.140000")]
+    value = HTML("<b>{:02d}</b><u>{:.3f}</u>").format(3, 3.14159)
+    assert to_formatted_text(value) == [("class:b", "03"), ("class:u", "3.142")]
 
 
 def test_merge_formatted_text():

--- a/tests/test_formatted_text.py
+++ b/tests/test_formatted_text.py
@@ -141,6 +141,9 @@ def test_html_interpolation():
     value = HTML("<b>{a}</b><u>{b}</u>").format(a="hello", b="world")
     assert to_formatted_text(value) == [("class:b", "hello"), ("class:u", "world")]
 
+    value = HTML("<b>{:d}</b><u>{:f}</u>").format(3, 3.14)
+    assert to_formatted_text(value) == [("class:b", "3"), ("class:u", "3.140000")]
+
 
 def test_merge_formatted_text():
     html1 = HTML("<u>hello</u>")


### PR DESCRIPTION
html_escape parameters after formatting, not before

Allows things like HTML("<b>{.3f}</b>").format(3.14159)