### PR TITLE
fix: right prompt not aligned correctly

### DIFF
--- a/src/prompt_toolkit/shortcuts/prompt.py
+++ b/src/prompt_toolkit/shortcuts/prompt.py
@@ -689,7 +689,7 @@ class PromptSession(Generic[_T]):
                         # The right prompt.
                         Float(
                             right=0,
-                            bottom=0,
+                            top=0,
                             hide_when_covering_content=True,
                             content=_RPrompt(lambda: self.rprompt),
                         ),


### PR DESCRIPTION
closes #1241

This is a fix suggested in one of the comments. I don't know the context, [why this change](https://github.com/prompt-toolkit/python-prompt-toolkit/commit/07e3429e50d49349c8bdb02e938825c9e1aa8c26) was first introduced at all. So let me know if the fix need to be improved.