### PR TITLE
Allow zero-width-escape sequences in `print_formatted_text`

### DIFF
--- a/src/prompt_toolkit/renderer.py
+++ b/src/prompt_toolkit/renderer.py
@@ -799,12 +799,16 @@ def print_formatted_text(
                 output.reset_attributes()
         last_attrs = attrs
 
-        # Eliminate carriage returns
-        text = text.replace("\r", "")
-
-        # Assume that the output is raw, and insert a carriage return before
-        # every newline. (Also important when the front-end is a telnet client.)
-        output.write(text.replace("\n", "\r\n"))
+        # Print escape sequences as raw output
+        if "[ZeroWidthEscape]" in style_str:
+            output.write_raw(text)
+        else:
+            # Eliminate carriage returns
+            text = text.replace("\r", "")
+            # Insert a carriage return before every newline (important when the
+            # front-end is a telnet client).
+            text = text.replace("\n", "\r\n")
+            output.write(text)
 
     # Reset again.
     output.reset_attributes()


### PR DESCRIPTION
Hello,

This PR enables `[ZeroWidthEscape]` fragments to be sent as raw output in `print_formatted_text`.

---

@jonathanslenders I'm a bit confused about what you meant by the comment:

>     # Assume that the output is raw

because you're using `output.write` here, so escape codes are removed. Was your intention to use `output.write_raw` for everything here?

Thanks