### PR TITLE
Add __bool__ to auto_suggest.Suggestion

### DIFF
--- a/src/prompt_toolkit/auto_suggest.py
+++ b/src/prompt_toolkit/auto_suggest.py
@@ -46,6 +46,9 @@ class Suggestion:
     def __repr__(self) -> str:
         return "Suggestion(%s)" % self.text
 
+    def __bool__(self) -> bool:
+        return bool(self.text)
+
 
 class AutoSuggest(metaclass=ABCMeta):
     """


### PR DESCRIPTION
This caught us by surprise in ipython/ipython#13624. It's easy to assume that `event.current_buffer.suggestion` is always either `None` or a non-zero length suggestion, but it turns out that it can actually be empty. This happens after accepting one suggestion and adding its text to the input. Afterwards, all subsequent events will have a `Suggestion` object with `self.text == ""`.