### PR TITLE
add default value option for input dialog

### DIFF
--- a/src/prompt_toolkit/shortcuts/dialogs.py
+++ b/src/prompt_toolkit/shortcuts/dialogs.py
@@ -109,7 +109,7 @@ def input_dialog(
     validator: Optional[Validator] = None,
     password: FilterOrBool = False,
     style: Optional[BaseStyle] = None,
-    default_text: str = "",
+    default: str = "",
 ) -> Application[str]:
     """
     Display a text input box.
@@ -127,7 +127,7 @@ def input_dialog(
     cancel_button = Button(text=cancel_text, handler=_return_none)
 
     textfield = TextArea(
-        text=default_text,
+        text=default,
         multiline=False,
         password=password,
         completer=completer,

--- a/src/prompt_toolkit/shortcuts/dialogs.py
+++ b/src/prompt_toolkit/shortcuts/dialogs.py
@@ -109,6 +109,7 @@ def input_dialog(
     validator: Optional[Validator] = None,
     password: FilterOrBool = False,
     style: Optional[BaseStyle] = None,
+    default_text: str = "",
 ) -> Application[str]:
     """
     Display a text input box.
@@ -126,6 +127,7 @@ def input_dialog(
     cancel_button = Button(text=cancel_text, handler=_return_none)
 
     textfield = TextArea(
+        text=default_text,
         multiline=False,
         password=password,
         completer=completer,


### PR DESCRIPTION
Hello
I like this library so much and use it for me personal projects thanks. This PR is similar to previous (#1563).

# What
I add an option to set default value for input dialog

# Usage
```python
from prompt_toolkit.shortcuts import input_dialog


def main():
    result = input_dialog(
                title="Input dialog example", 
                text="Please type your name:", 
                default_text="George"
            ).run()

    print(f"Result = {result}")


if __name__ == "__main__":
    main()
```

# How it works
- without edit
![default_value](https://user-images.githubusercontent.com/11750226/163355348-9b560151-08c3-42e6-945c-602cb817c883.gif)

- editing
![edit](https://user-images.githubusercontent.com/11750226/163355343-682ba84a-21f9-460c-829f-2d6717cdb3ea.gif)

# Related
- issue
  -  #1544 
- PR
  - #1563 (me)