### PR TITLE
Add documentation for WindowRenderInfo, Point, Size

### DIFF
--- a/docs/pages/reference.rst
+++ b/docs/pages/reference.rst
@@ -383,6 +383,18 @@ Output
     :members:
 
 
+Data structures
+---------------
+
+.. autoclass:: prompt_toolkit.layout.WindowRenderInfo
+    :members:
+
+.. autoclass:: prompt_toolkit.data_structures.Point
+    :members:
+
+.. autoclass:: prompt_toolkit.data_structures.Size
+    :members:
+
 Patch stdout
 ------------
 


### PR DESCRIPTION
These classes are mentioned a few times in the reference but their documentation wasn't visible.
`Point` and `Size` might use some improvements, I added them mostly to make it possible to reference them properly.

![image](https://user-images.githubusercontent.com/6691643/167234639-d14cf46e-cbbb-4e69-88cb-d9060e98557d.png)

![image](https://user-images.githubusercontent.com/6691643/167234626-10568d85-62ad-482b-8095-91fbbd51c626.png)
