### PR TITLE
added a configurable default mode so we don't have to start in INSERT

### DIFF
--- a/src/prompt_toolkit/key_binding/vi_state.py
+++ b/src/prompt_toolkit/key_binding/vi_state.py
@@ -55,6 +55,9 @@ class ViState:
         #: The Vi mode we're currently in to.
         self.__input_mode = InputMode.INSERT
 
+        #: The Vi mode that gets applied when reset() is called
+        self.default_input_mode = InputMode.INSERT
+
         #: Waiting for digraph.
         self.waiting_for_digraph = False
         self.digraph_symbol1: Optional[str] = None  # (None or a symbol.)
@@ -96,7 +99,7 @@ class ViState:
         Reset state, go back to the given mode. INSERT by default.
         """
         # Go back to insert mode.
-        self.input_mode = InputMode.INSERT
+        self.input_mode = self.default_input_mode
 
         self.waiting_for_digraph = False
         self.operator_func = None


### PR DESCRIPTION
If accepted, this would fix https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1631

Usage looks like this:
```
    app = Application(
        key_bindings=kb, layout=Layout(root_container), editing_mode=EditingMode.VI
    )
    app.vi_state.default_input_mode = InputMode.NAVIGATION
    app.reset()
    app.run()
```

I'm not confident about the bigger picture here.  Like maybe there's a way to do this that fits better with the many other ways to use prompt-toolkit.  All I can say is that it works well in my case.