### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/prompt_toolkit/cursor_shapes.py
+++ b/src/prompt_toolkit/cursor_shapes.py
@@ -25,7 +25,7 @@ class CursorShape(Enum):
     # prompt_toolkit itself, people had workarounds to send cursor shapes
     # escapes into the terminal, by monkey patching some of prompt_toolkit's
     # internals. We don't want the default prompt_toolkit implemetation to
-    # interefere with that. E.g., IPython patches the `ViState.input_mode`
+    # interfere with that. E.g., IPython patches the `ViState.input_mode`
     # property. See: https://github.com/ipython/ipython/pull/13501/files
     _NEVER_CHANGE = "_NEVER_CHANGE"
 

--- a/src/prompt_toolkit/key_binding/bindings/vi.py
+++ b/src/prompt_toolkit/key_binding/bindings/vi.py
@@ -1861,7 +1861,7 @@ def load_vi_bindings() -> KeyBindingsBase:
         )
         def _arg(event: E) -> None:
             """
-            Always handle numberics in navigation mode as arg.
+            Always handle numerics in navigation mode as arg.
             """
             event.append_to_arg_count(event.data)
 


### PR DESCRIPTION
There are small typos in:
- src/prompt_toolkit/cursor_shapes.py
- src/prompt_toolkit/key_binding/bindings/vi.py

Fixes:
- Should read `numerics` rather than `numberics`.
- Should read `interfere` rather than `interefere`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md