### PR TITLE
restrict to certain vim modes

### DIFF
--- a/src/prompt_toolkit/key_binding/vi_state.py
+++ b/src/prompt_toolkit/key_binding/vi_state.py
@@ -55,6 +55,9 @@ class ViState:
         #: The Vi mode we're currently in to.
         self.__input_mode = InputMode.INSERT
 
+        #: Prevent input modes not listed here
+        self.allowed_input_modes = list(InputMode)
+
         #: Waiting for digraph.
         self.waiting_for_digraph = False
         self.digraph_symbol1: Optional[str] = None  # (None or a symbol.)
@@ -89,7 +92,8 @@ class ViState:
             self.operator_func = None
             self.operator_arg = None
 
-        self.__input_mode = value
+        if value in self.allowed_input_modes:
+            self.__input_mode = value
 
     def reset(self) -> None:
         """


### PR DESCRIPTION
I am working on an app that uses prompt-toolkit to let users delete subsets of a string, but it's invalid to add anything to that string.  In this case I want the prompt to be stuck in NAVIGATION mode.

After making this change to prompt toolkit, I can use it like so:
```
app.vi_state.allowed_input_modes = [InputMode.NAVIGATION]
app.run()
```

If there's a better way to achieve this, I'd be interested to hear about it.  Thanks.