### PR TITLE
Correct type hint for `OneStyleAndTextTuple` callable

### DIFF
--- a/src/prompt_toolkit/formatted_text/base.py
+++ b/src/prompt_toolkit/formatted_text/base.py
@@ -5,6 +5,8 @@ from prompt_toolkit.mouse_events import MouseEvent
 if TYPE_CHECKING:
     from typing_extensions import Protocol
 
+    from prompt_toolkit.key_binding.key_bindings import NotImplementedOrNone
+
 __all__ = [
     "OneStyleAndTextTuple",
     "StyleAndTextTuples",
@@ -18,7 +20,7 @@ __all__ = [
 ]
 
 OneStyleAndTextTuple = Union[
-    Tuple[str, str], Tuple[str, str, Callable[[MouseEvent], None]]
+    Tuple[str, str], Tuple[str, str, Callable[[MouseEvent], "NotImplementedOrNone"]]
 ]
 
 # List of (style, text) tuples.


### PR DESCRIPTION
Hi,

I think the type of a `StyleAndTextTuple` should allow `NotImplemented` to be returned by the mouse handler, as is the case for other mouse handlers.