### PR TITLE
Create background tasks on application's loop

### DIFF
--- a/src/prompt_toolkit/application/application.py
+++ b/src/prompt_toolkit/application/application.py
@@ -1077,7 +1077,8 @@ class Application(Generic[_AppResult]):
 
         This is not threadsafe.
         """
-        task: asyncio.Task[None] = get_event_loop().create_task(coroutine)
+        loop = self.loop or get_event_loop()
+        task: asyncio.Task[None] = loop.create_task(coroutine)
         self._background_tasks.add(task)
 
         task.add_done_callback(self._on_background_task_done)


### PR DESCRIPTION
I'm trying to load parts of my application (including a `Buffer` with history) in a background thread. However, when the background tasks are waited for at exit, I get the following error:

```
ValueError: The future belongs to a different loop than the one specified as the loop argument
```

The reason for this is that the buffer history loading task gets scheduled in the event loop in the background thread instead of in the main application loop.

This PR ensures that an application's background tasks always get created on the application's event loop (if it exists).
