### PR TITLE
Copy over show_cursor attribute from screen

### DIFF
--- a/src/prompt_toolkit/layout/scrollable_pane.py
+++ b/src/prompt_toolkit/layout/scrollable_pane.py
@@ -146,6 +146,7 @@ class ScrollablePane(Container):
         # First, write the content to a virtual screen, then copy over the
         # visible part to the real screen.
         temp_screen = Screen(default_char=Char(char=" ", style=parent_style))
+        temp_screen.show_cursor = screen.show_cursor
         temp_write_position = WritePosition(
             xpos=0, ypos=0, width=virtual_width, height=virtual_height
         )


### PR DESCRIPTION
If a ScrollablePane instance does not have focus, it will show the cursor of the currently focused window even if that window has show_cursor set to False. This is because the virtual screen does not copy over the show_cursor attribute from screen to the virtual screen.