### PR TITLE
Make VERSION tuple numeric.

### DIFF
--- a/src/prompt_toolkit/__init__.py
+++ b/src/prompt_toolkit/__init__.py
@@ -13,6 +13,13 @@ See the examples directory to learn about the usage.
 Probably, to get started, you might also want to have a look at
 `prompt_toolkit.shortcuts.prompt`.
 """
+import re
+
+# note: this is a bit more lax than the actual pep 440 to allow for a/b/rc/dev without a number
+pep440 = re.compile(
+    r"^([1-9]\d*!)?(0|[1-9]\d*)(\.(0|[1-9]\d*))*((a|b|rc)(0|[1-9]\d*)?)?(\.post(0|[1-9]\d*))?(\.dev(0|[1-9]\d*)?)?$",
+    re.UNICODE,
+)
 from .application import Application
 from .formatted_text import ANSI, HTML
 from .shortcuts import PromptSession, print_formatted_text, prompt
@@ -20,8 +27,10 @@ from .shortcuts import PromptSession, print_formatted_text, prompt
 # Don't forget to update in `docs/conf.py`!
 __version__ = "3.0.36"
 
+assert pep440.match(__version__)
+
 # Version tuple.
-VERSION = tuple(__version__.split("."))
+VERSION = tuple(int(v.rstrip("abrc")) for v in __version__.split(".")[:3])
 
 
 __all__ = [


### PR DESCRIPTION
Note that by being numeric we drop the rc/a/b/dev suffix. I'm also adding the pep440 regular expression to make sure the version number match the spec.

The pep 440 spec is a bit annoying with the fact that a/b/rc don't have dots, but .dev do.

There are some issues if you don't follow the spec and publish both whl/tgz, as pip will mix-up the values, and think the tgz are actually a more recent version than the whl. It may be fixed in setuptools/pip, but better be safe.

Ii did not go the route of setting VERSION and having __version__ be a '.'.join() as setup.py use regex to extract version number.

Maye docs/conf.py could also use the same trick as setup.py to avoid having to update the version number in multiple places ?

Closes #1707