### PR TITLE
MNT: Avoid warning on 3.10.9+, 3.11.1+, and 3.12.0+

### DIFF
--- a/src/prompt_toolkit/eventloop/utils.py
+++ b/src/prompt_toolkit/eventloop/utils.py
@@ -115,4 +115,6 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         return getloop()
     except RuntimeError:
-        return asyncio.get_event_loop_policy().get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop


### PR DESCRIPTION
closes #1696