### PR TITLE
Partial suggestion filling for path parts

### DIFF
--- a/src/prompt_toolkit/key_binding/bindings/auto_suggest.py
+++ b/src/prompt_toolkit/key_binding/bindings/auto_suggest.py
@@ -57,7 +57,7 @@ def load_auto_suggest_bindings() -> KeyBindings:
         suggestion = b.suggestion
 
         if suggestion:
-            t = re.split(r"(\S+\s+)", suggestion.text)
+            t = re.split(r"([^\s/]+(?:\s+|/)", suggestion.text)
             b.insert_text(next(x for x in t if x))
 
     return key_bindings

--- a/src/prompt_toolkit/key_binding/bindings/auto_suggest.py
+++ b/src/prompt_toolkit/key_binding/bindings/auto_suggest.py
@@ -57,7 +57,7 @@ def load_auto_suggest_bindings() -> KeyBindings:
         suggestion = b.suggestion
 
         if suggestion:
-            t = re.split(r"([^\s/]+(?:\s+|/)", suggestion.text)
+            t = re.split(r"([^\s/]+(?:\s+|/))", suggestion.text)
             b.insert_text(next(x for x in t if x))
 
     return key_bindings


### PR DESCRIPTION
This makes the ctrl+right partial suggestion filling take into account path parts, as it does in fish. To be precise, if the user has typed `python /home/l` and has been shown the suggestion `python /home/lgrobol/test.py`, hitting ctrl+right will only partial fill up to `python /home/lgrobol/` instead of  `python /home/lgrobol/test.py` (current behaviour).