### PR TITLE
[fix memory leak]PromptSession wouldn't free

### DIFF
--- a/src/prompt_toolkit/filters/app.py
+++ b/src/prompt_toolkit/filters/app.py
@@ -176,12 +176,13 @@ def has_arg() -> bool:
     return get_app().key_processor.arg is not None
 
 
-@Condition
 def is_done() -> bool:
     """
     True when the CLI is returning, aborting or exiting.
     """
     return get_app().is_done
+
+is_done = Condition(is_done, can_cache=False)
 
 
 @Condition


### PR DESCRIPTION
Reference: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1688

I updated to the latest `python-prompt-toolkit` and found that it still has memory leaks.
It's seems that the default `AppSession` in `_current_app_session` holds some `Filter` objects and indirectly holds `PromptSession` objects. 
If I remove `is_done` and `Always` from filter's cache, `PromptSession` objects can be freed.
I added a `can_cache` argument to Filter to prevent `is_done` from being cached, and made `Always` a singleton.
After these changes `PromptSession` can be freed.

Unresolved bug:
If I called `await session.prompt_async()`  one `PromptSession` is not freed.

```python
import asyncio
import gc

from prompt_toolkit import PromptSession


async def create_session():
    try:
        session = PromptSession()
        # await session.prompt_async()
    except KeyboardInterrupt:
        print("pass")
    del session
    gc.collect()


async def m():
    for _ in range(5):
        await create_session()
    gc.collect()
    obj = gc.get_objects()
    print('len', len([o for o in obj if isinstance(o, PromptSession)]))

asyncio.run(m())
```