### PR TITLE
change filters's order to fix memory leak

### DIFF
--- a/src/prompt_toolkit/layout/menus.py
+++ b/src/prompt_toolkit/layout/menus.py
@@ -289,7 +289,7 @@ class CompletionsMenu(ConditionalContainer):
             ),
             # Show when there are completions but not at the point we are
             # returning the input.
-            filter=has_completions & ~is_done & extra_filter,
+            filter=extra_filter & has_completions & ~is_done,
         )
 
 
@@ -647,7 +647,7 @@ class MultiColumnCompletionsMenu(HSplit):
 
         # Display filter: show when there are completions but not at the point
         # we are returning the input.
-        full_filter = has_completions & ~is_done & extra_filter
+        full_filter = extra_filter & has_completions & ~is_done
 
         @Condition
         def any_completion_has_meta() -> bool:
@@ -676,7 +676,7 @@ class MultiColumnCompletionsMenu(HSplit):
 
         meta_window = ConditionalContainer(
             content=Window(content=_SelectedCompletionMetaControl()),
-            filter=show_meta & full_filter & any_completion_has_meta,
+            filter=full_filter & show_meta & any_completion_has_meta,
         )
 
         # Initialise split.

--- a/src/prompt_toolkit/shortcuts/prompt.py
+++ b/src/prompt_toolkit/shortcuts/prompt.py
@@ -571,9 +571,9 @@ class PromptSession(Generic[_T]):
                 dont_extend_height=True,
                 height=Dimension(min=1),
             ),
-            filter=~is_done
-            & renderer_height_is_known
-            & Condition(lambda: self.bottom_toolbar is not None),
+            filter=Condition(lambda: self.bottom_toolbar is not None)
+            & ~is_done
+            & renderer_height_is_known,
         )
 
         search_toolbar = SearchToolbar(


### PR DESCRIPTION
Reference: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1688

I updated to the latest `python-prompt-toolkit` and found that it still has memory leaks.
If a filter cached by a global filter function, such as `def is_done()`, the filter cannot be freed.  Filter operations should be very careful to avoid using global filters as the first filter.

Unresolved bug:
If I called `await session.prompt_async()`  one `PromptSession` is not freed.

```python
import sys
import asyncio
import gc
from prompt_toolkit import PromptSession

async def create_session():
    try:
        session = PromptSession()
        # await session.prompt_async()
    except KeyboardInterrupt:
        print("pass")
    del session
    gc.collect()

async def m():
    for _ in range(5):
        await create_session()
    gc.collect()
    obj = gc.get_objects()
    print('len', len([o for o in obj if isinstance(o, PromptSession)]))

asyncio.run(m())
```