### PR TITLE
in_thread keyword is passed through 'prompt' shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ docs/_build
 # pycharm metadata
 .idea
 
+# vscode metadata
+.vscode
+
 # virtualenvs
 .venv*

--- a/src/prompt_toolkit/layout/utils.py
+++ b/src/prompt_toolkit/layout/utils.py
@@ -56,7 +56,7 @@ class _ExplodedList(List[_T]):
         if isinstance(value, tuple):  # In case of `OneStyleAndTextTuple`.
             value = cast("List[_T]", [value])
 
-        super().__setitem__(index, explode_text_fragments(cast("Iterable[_T]", value)))
+        super().__setitem__(index, explode_text_fragments(value))
 
 
 def explode_text_fragments(fragments: Iterable[_T]) -> _ExplodedList[_T]:

--- a/src/prompt_toolkit/shortcuts/prompt.py
+++ b/src/prompt_toolkit/shortcuts/prompt.py
@@ -1393,6 +1393,7 @@ def prompt(
     enable_open_in_editor: FilterOrBool | None = None,
     tempfile_suffix: str | Callable[[], str] | None = None,
     tempfile: str | Callable[[], str] | None = None,
+    in_thread: bool = False,
     # Following arguments are specific to the current `prompt()` call.
     default: str = "",
     accept_default: bool = False,
@@ -1447,6 +1448,7 @@ def prompt(
         default=default,
         accept_default=accept_default,
         pre_run=pre_run,
+        in_thread=in_thread,
     )
 
 


### PR DESCRIPTION
Hello!
First, thank you you all for such a powerful toolkit making absolutely easy to use interactive prompts. 
I develop an async code debugging tool based on clic_repl. I call click_repl session rigth from inside a coroutine.
click_repl in turn uses the toolkit to manage a prompt. It calls your `prompt_toolkit.shortcut.prompt.prompt` passing all the arguments as a dictionary. 
My issue is that I call it from inside a coroutine and I must pass `in_thread = True` because my loop is already  running. 
And this keyword is not passed further for some reason. 
This PR fixes it. 