### PR TITLE
Fix doc example for progress bar with custom iterable

### DIFF
--- a/docs/pages/progress_bars.rst
+++ b/docs/pages/progress_bars.rst
@@ -50,7 +50,7 @@ in order to make displaying the progress possible:
         yield ...
 
     with ProgressBar() as pb:
-        for i in pb(some_iterable, total=1000):
+        for i in pb(some_iterable(), total=1000):
             time.sleep(.01)
 
 


### PR DESCRIPTION
When I tried the example as it was, I got the following exception:

```
$ cat /tmp/try_prompt.py 
from prompt_toolkit.shortcuts import ProgressBar
import time

def some_iterable():
    yield ...

with ProgressBar() as pb:
    for i in pb(some_iterable, total=1000):
        time.sleep(.01)

$ python3 /tmp/try_prompt.py
   0.0% [>                                                                                                                  ]   0/1000  eta [?:??:??]
Traceback (most recent call last):
  File "/tmp/try_prompt.py", line 8, in <module>
    for i in pb(some_iterable, total=1000):
  File "/home/pradeep/.pyenv/versions/3.10.8/lib/python3.10/site-packages/prompt_toolkit/shortcuts/progress_bar/base.py", line 353, in __iter__
    for item in self.data:
TypeError: 'function' object is not iterable
```

After changing the iterable to `some_iterable()`, things worked as expected:

```
$ python3 /tmp/try_prompt.py 
   0.1% [====================================================================================================================>]   1/1000  eta [00:00]

```