### PR TITLE
feat(keymap): add indent/dedent in insert mode

### DIFF
--- a/src/prompt_toolkit/buffer.py
+++ b/src/prompt_toolkit/buffer.py
@@ -1936,18 +1936,18 @@ def indent(buffer: Buffer, from_row: int, to_row: int, count: int = 1) -> None:
     Indent text of a :class:`.Buffer` object.
     """
     current_row = buffer.document.cursor_position_row
+    current_col = buffer.document.cursor_position_col
     line_range = range(from_row, to_row)
 
     # Apply transformation.
-    new_text = buffer.transform_lines(line_range, lambda l: "    " * count + l)
+    indent_content = "    " * count
+    new_text = buffer.transform_lines(line_range, lambda l: indent_content + l)
     buffer.document = Document(
         new_text, Document(new_text).translate_row_col_to_index(current_row, 0)
     )
 
-    # Go to the start of the line.
-    buffer.cursor_position += buffer.document.get_start_of_line_position(
-        after_whitespace=True
-    )
+    # Place cursor in the same position in text after indenting
+    buffer.cursor_position += current_col + len(indent_content)
 
 
 def unindent(buffer: Buffer, from_row: int, to_row: int, count: int = 1) -> None:
@@ -1955,10 +1955,13 @@ def unindent(buffer: Buffer, from_row: int, to_row: int, count: int = 1) -> None
     Unindent text of a :class:`.Buffer` object.
     """
     current_row = buffer.document.cursor_position_row
+    current_col = buffer.document.cursor_position_col
     line_range = range(from_row, to_row)
 
+    indent_content = "    " * count
+
     def transform(text: str) -> str:
-        remove = "    " * count
+        remove = indent_content
         if text.startswith(remove):
             return text[len(remove) :]
         else:
@@ -1970,10 +1973,8 @@ def unindent(buffer: Buffer, from_row: int, to_row: int, count: int = 1) -> None
         new_text, Document(new_text).translate_row_col_to_index(current_row, 0)
     )
 
-    # Go to the start of the line.
-    buffer.cursor_position += buffer.document.get_start_of_line_position(
-        after_whitespace=True
-    )
+    # Place cursor in the same position in text after dedent
+    buffer.cursor_position += current_col - len(indent_content)
 
 
 def reshape_text(buffer: Buffer, from_row: int, to_row: int) -> None:

--- a/src/prompt_toolkit/key_binding/bindings/vi.py
+++ b/src/prompt_toolkit/key_binding/bindings/vi.py
@@ -962,6 +962,7 @@ def load_vi_bindings() -> KeyBindingsBase:
         )
 
     @handle(">", ">", filter=vi_navigation_mode)
+    @handle("c-t", filter=vi_insert_mode)
     def _indent(event: E) -> None:
         """
         Indent lines.
@@ -971,6 +972,7 @@ def load_vi_bindings() -> KeyBindingsBase:
         indent(buffer, current_row, current_row + event.arg)
 
     @handle("<", "<", filter=vi_navigation_mode)
+    @handle("c-d", filter=vi_insert_mode)
     def _unindent(event: E) -> None:
         """
         Unindent lines.


### PR DESCRIPTION
`ctrl-t` to indent in insert mode
`ctrl-d` to dedent in insert mode

also, this commit place cursor after indent/dedent in the same place in the text instead of  placing it at the beginning of the line.