### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,15 +9,17 @@ jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install Dependencies
         run: |
           sudo apt remove python3-pip

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python",
         "Topic :: Software Development",

--- a/src/prompt_toolkit/application/application.py
+++ b/src/prompt_toolkit/application/application.py
@@ -1005,7 +1005,7 @@ class Application(Generic[_AppResult]):
         manager. (We will only install the hook if no other custom hook was
         set.)
         """
-        if sys.version_info >= (3, 7) and sys.breakpointhook == sys.__breakpointhook__:
+        if sys.breakpointhook == sys.__breakpointhook__:
             sys.breakpointhook = self._breakpointhook
 
             try:

--- a/src/prompt_toolkit/application/current.py
+++ b/src/prompt_toolkit/application/current.py
@@ -144,10 +144,8 @@ def create_app_session(
     Create a separate AppSession.
 
     This is useful if there can be multiple individual `AppSession`s going on.
-    Like in the case of an Telnet/SSH server. This functionality uses
-    contextvars and requires at least Python 3.7.
+    Like in the case of an Telnet/SSH server.
     """
-
     # If no input/output is specified, fall back to the current input/output,
     # whatever that is.
     if input is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,7 +190,7 @@ def test_emacs_cursor_movements():
 def test_emacs_kill_multiple_words_and_paste():
     # Using control-w twice should place both words on the clipboard.
     result, cli = _feed_cli_with_input(
-        "hello world test" "\x17\x17" "--\x19\x19\r"  # Twice c-w.  # Twice c-y.
+        "hello world test\x17\x17--\x19\x19\r"  # Twice c-w.  Twice c-y.
     )
     assert result.text == "hello --world testworld test"
     assert cli.clipboard.get_data().text == "world test"

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35, pypy, pypy3
+envlist = py{37, 38, 39, 310, 311, 312, py3}
 
 [testenv]
-commands = py.test []
+commands = pytest []
 
 deps=
     pytest


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/

---

Also upgraded Python syntax with https://github.com/asottile/pyupgrade `--py38-plus`.