### PR TITLE
Add 'build.os' params to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 formats:
   - pdf
   - epub


### PR DESCRIPTION
This PR adds the now required section `build` to the `.readthedocs.yml` file.