### PR TITLE
Fix inputhook implementation to be compatible with asyncio.run().

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,8 +36,9 @@ jobs:
       - name: Tests
         run: |
           coverage run -m pytest
-      - name: Mypy
-        # Check wheather the imports were sorted correctly.
+      - if: "matrix.python-version != '3.7'"
+        name: Mypy
+        # Check whether the imports were sorted correctly.
         # When this fails, please run ./tools/sort-imports.sh
         run: |
           mypy --strict src/prompt_toolkit --platform win32

--- a/src/prompt_toolkit/application/dummy.py
+++ b/src/prompt_toolkit/application/dummy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+from prompt_toolkit.eventloop import InputHook
 from prompt_toolkit.formatted_text import AnyFormattedText
 from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
@@ -28,6 +29,7 @@ class DummyApplication(Application[None]):
         set_exception_handler: bool = True,
         handle_sigint: bool = True,
         in_thread: bool = False,
+        inputhook: InputHook | None = None,
     ) -> None:
         raise NotImplementedError("A DummyApplication is not supposed to run.")
 

--- a/src/prompt_toolkit/eventloop/__init__.py
+++ b/src/prompt_toolkit/eventloop/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .async_generator import aclosing, generator_to_async_generator
 from .inputhook import (
+    InputHook,
     InputHookContext,
     InputHookSelector,
     new_eventloop_with_inputhook,
@@ -22,6 +23,7 @@ __all__ = [
     "call_soon_threadsafe",
     "get_traceback_from_context",
     # Inputhooks.
+    "InputHook",
     "new_eventloop_with_inputhook",
     "set_eventloop_with_inputhook",
     "InputHookSelector",

--- a/src/prompt_toolkit/eventloop/inputhook.py
+++ b/src/prompt_toolkit/eventloop/inputhook.py
@@ -39,12 +39,30 @@ __all__ = [
     "set_eventloop_with_inputhook",
     "InputHookSelector",
     "InputHookContext",
+    "InputHook",
 ]
 
 if TYPE_CHECKING:
     from _typeshed import FileDescriptorLike
+    from typing_extensions import TypeAlias
 
     _EventMask = int
+
+
+class InputHookContext:
+    """
+    Given as a parameter to the inputhook.
+    """
+
+    def __init__(self, fileno: int, input_is_ready: Callable[[], bool]) -> None:
+        self._fileno = fileno
+        self.input_is_ready = input_is_ready
+
+    def fileno(self) -> int:
+        return self._fileno
+
+
+InputHook: TypeAlias = Callable[[InputHookContext], None]
 
 
 def new_eventloop_with_inputhook(
@@ -64,6 +82,8 @@ def set_eventloop_with_inputhook(
     """
     Create a new event loop with the given inputhook, and activate it.
     """
+    # Deprecated!
+
     loop = new_eventloop_with_inputhook(inputhook)
     asyncio.set_event_loop(loop)
     return loop
@@ -168,16 +188,3 @@ class InputHookSelector(BaseSelector):
 
     def get_map(self) -> Mapping[FileDescriptorLike, SelectorKey]:
         return self.selector.get_map()
-
-
-class InputHookContext:
-    """
-    Given as a parameter to the inputhook.
-    """
-
-    def __init__(self, fileno: int, input_is_ready: Callable[[], bool]) -> None:
-        self._fileno = fileno
-        self.input_is_ready = input_is_ready
-
-    def fileno(self) -> int:
-        return self._fileno

--- a/src/prompt_toolkit/layout/controls.py
+++ b/src/prompt_toolkit/layout/controls.py
@@ -449,7 +449,7 @@ class FormattedTextControl(UIControl):
                             # Handler found. Call it.
                             # (Handler can return NotImplemented, so return
                             # that result.)
-                            handler = item[2]  # type: ignore
+                            handler = item[2]
                             return handler(mouse_event)
                         else:
                             break

--- a/src/prompt_toolkit/shortcuts/prompt.py
+++ b/src/prompt_toolkit/shortcuts/prompt.py
@@ -45,6 +45,7 @@ from prompt_toolkit.cursor_shapes import (
 )
 from prompt_toolkit.document import Document
 from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER, EditingMode
+from prompt_toolkit.eventloop import InputHook
 from prompt_toolkit.filters import (
     Condition,
     FilterOrBool,
@@ -892,6 +893,7 @@ class PromptSession(Generic[_T]):
         set_exception_handler: bool = True,
         handle_sigint: bool = True,
         in_thread: bool = False,
+        inputhook: InputHook | None = None,
     ) -> _T:
         """
         Display the prompt.
@@ -1025,6 +1027,7 @@ class PromptSession(Generic[_T]):
             set_exception_handler=set_exception_handler,
             in_thread=in_thread,
             handle_sigint=handle_sigint,
+            inputhook=inputhook,
         )
 
     @contextmanager
@@ -1393,11 +1396,14 @@ def prompt(
     enable_open_in_editor: FilterOrBool | None = None,
     tempfile_suffix: str | Callable[[], str] | None = None,
     tempfile: str | Callable[[], str] | None = None,
-    in_thread: bool = False,
     # Following arguments are specific to the current `prompt()` call.
     default: str = "",
     accept_default: bool = False,
     pre_run: Callable[[], None] | None = None,
+    set_exception_handler: bool = True,
+    handle_sigint: bool = True,
+    in_thread: bool = False,
+    inputhook: InputHook | None = None,
 ) -> str:
     """
     The global `prompt` function. This will create a new `PromptSession`
@@ -1448,7 +1454,10 @@ def prompt(
         default=default,
         accept_default=accept_default,
         pre_run=pre_run,
+        set_exception_handler=set_exception_handler,
+        handle_sigint=handle_sigint,
         in_thread=in_thread,
+        inputhook=inputhook,
     )
 
 


### PR DESCRIPTION
`asyncio.get_event_loop()` got deprecated. So we can't install an event loop with inputhook upfront and then use in in prompt_toolkit. Instead, we can take the inputhook as an argument in `Application.run()` and `PromptSession.run()`, and install it in the event loop that we create ourselves using `asyncio.run()`.