### PR TITLE
Bounded file history

### DIFF
--- a/src/prompt_toolkit/layout/controls.py
+++ b/src/prompt_toolkit/layout/controls.py
@@ -477,7 +477,9 @@ class DummyControl(UIControl):
         def get_line(i: int) -> StyleAndTextTuples:
             return []
 
-        return UIContent(get_line=get_line, line_count=100**100)  # Something very big.
+        return UIContent(
+            get_line=get_line, line_count=100**100
+        )  # Something very big.
 
     def is_focusable(self) -> bool:
         return False


### PR DESCRIPTION
This limits the number of history entries which are loaded on a complete reload. It probably would also be possible to truncate the in-memory history, but I have not done that for now..