### PR TITLE
Disable workaround for ipython >= 8.18

### DIFF
--- a/src/prompt_toolkit/application/application.py
+++ b/src/prompt_toolkit/application/application.py
@@ -960,7 +960,8 @@ class Application(Generic[_AppResult]):
         def _called_from_ipython() -> bool:
             try:
                 return (
-                    "IPython/terminal/interactiveshell.py"
+                    sys.modules["IPython"].version_info < (8, 18, 0, "")
+                    and "IPython/terminal/interactiveshell.py"
                     in sys._getframe(3).f_code.co_filename
                 )
             except BaseException:


### PR DESCRIPTION
Since ipython 8.18 already merged https://github.com/ipython/ipython/pull/14241, this workaround is no longer necessary. Moreover, the workaround gives a deprecation warning in python 3.12.

This PR uses the test `sys.modules['IPython'].version_info < (8, 18, 0, '')` to apply the workaround only in older ipython.

In case the IPython module is not loaded this will `raise `KeyError` and correctly `return False` thanks to the `except BaseException` already there.

See: https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1811#issuecomment-1827043359

Cc: @jonathanslenders