### PR TITLE
Use Coroutine instead of Awaitable in type annotations where possible.

### DIFF
--- a/src/prompt_toolkit/buffer.py
+++ b/src/prompt_toolkit/buffer.py
@@ -15,7 +15,7 @@ import tempfile
 from collections import deque
 from enum import Enum
 from functools import wraps
-from typing import Any, Awaitable, Callable, Coroutine, Iterable, TypeVar, cast
+from typing import Any, Callable, Coroutine, Iterable, TypeVar, cast
 
 from .application.current import get_app
 from .application.run_in_terminal import run_in_terminal
@@ -1891,7 +1891,7 @@ class Buffer:
                 self.reset()
 
 
-_T = TypeVar("_T", bound=Callable[..., Awaitable[None]])
+_T = TypeVar("_T", bound=Callable[..., Coroutine[Any, Any, None]])
 
 
 def _only_one_at_a_time(coroutine: _T) -> _T:

--- a/src/prompt_toolkit/contrib/ssh/server.py
+++ b/src/prompt_toolkit/contrib/ssh/server.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import traceback
 from asyncio import get_running_loop
-from typing import Any, Awaitable, Callable, TextIO, cast
+from typing import Any, Callable, Coroutine, TextIO, cast
 
 import asyncssh
 
@@ -21,7 +21,7 @@ __all__ = ["PromptToolkitSSHSession", "PromptToolkitSSHServer"]
 class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
     def __init__(
         self,
-        interact: Callable[[PromptToolkitSSHSession], Awaitable[None]],
+        interact: Callable[[PromptToolkitSSHSession], Coroutine[Any, Any, None]],
         *,
         enable_cpr: bool,
     ) -> None:
@@ -162,7 +162,7 @@ class PromptToolkitSSHServer(asyncssh.SSHServer):
 
     def __init__(
         self,
-        interact: Callable[[PromptToolkitSSHSession], Awaitable[None]],
+        interact: Callable[[PromptToolkitSSHSession], Coroutine[Any, Any, None]],
         *,
         enable_cpr: bool = True,
     ) -> None:

--- a/src/prompt_toolkit/contrib/telnet/server.py
+++ b/src/prompt_toolkit/contrib/telnet/server.py
@@ -7,7 +7,7 @@ import asyncio
 import contextvars
 import socket
 from asyncio import get_running_loop
-from typing import Awaitable, Callable, TextIO, cast
+from typing import Any, Callable, Coroutine, TextIO, cast
 
 from prompt_toolkit.application.current import create_app_session, get_app
 from prompt_toolkit.application.run_in_terminal import run_in_terminal
@@ -124,7 +124,7 @@ class TelnetConnection:
         self,
         conn: socket.socket,
         addr: tuple[str, int],
-        interact: Callable[[TelnetConnection], Awaitable[None]],
+        interact: Callable[[TelnetConnection], Coroutine[Any, Any, None]],
         server: TelnetServer,
         encoding: str,
         style: BaseStyle | None,
@@ -283,7 +283,9 @@ class TelnetServer:
         self,
         host: str = "127.0.0.1",
         port: int = 23,
-        interact: Callable[[TelnetConnection], Awaitable[None]] = _dummy_interact,
+        interact: Callable[
+            [TelnetConnection], Coroutine[Any, Any, None]
+        ] = _dummy_interact,
         encoding: str = "utf-8",
         style: BaseStyle | None = None,
         enable_cpr: bool = True,

--- a/src/prompt_toolkit/key_binding/key_bindings.py
+++ b/src/prompt_toolkit/key_binding/key_bindings.py
@@ -40,8 +40,9 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from inspect import isawaitable
 from typing import (
     TYPE_CHECKING,
-    Awaitable,
+    Any,
     Callable,
+    Coroutine,
     Hashable,
     Sequence,
     Tuple,
@@ -89,7 +90,8 @@ __all__ = [
 # This is mainly used in case of mouse move events, to prevent excessive
 # repainting during mouse move events.
 KeyHandlerCallable = Callable[
-    ["KeyPressEvent"], Union["NotImplementedOrNone", Awaitable["NotImplementedOrNone"]]
+    ["KeyPressEvent"],
+    Union["NotImplementedOrNone", Coroutine[Any, Any, "NotImplementedOrNone"]],
 ]
 
 
@@ -125,7 +127,7 @@ class Binding:
 
         # If the handler is a coroutine, create an asyncio task.
         if isawaitable(result):
-            awaitable = cast(Awaitable["NotImplementedOrNone"], result)
+            awaitable = cast(Coroutine[Any, Any, "NotImplementedOrNone"], result)
 
             async def bg_task() -> None:
                 result = await awaitable


### PR DESCRIPTION
One step towards better use of structured concurrency.