### PR TITLE
fix memory leak for prompt_toolkit.filters.base.Never/Always and inline condition filter

### DIFF
--- a/src/prompt_toolkit/filters/base.py
+++ b/src/prompt_toolkit/filters/base.py
@@ -207,6 +207,9 @@ class Always(Filter):
     def __or__(self, other: Filter) -> Filter:
         return self
 
+    def __and__(self, other: Filter) -> Filter:
+        return other
+
     def __invert__(self) -> Never:
         return Never()
 
@@ -221,6 +224,9 @@ class Never(Filter):
 
     def __and__(self, other: Filter) -> Filter:
         return self
+
+    def __or__(self, other: Filter) -> Filter:
+        return other
 
     def __invert__(self) -> Always:
         return Always()

--- a/src/prompt_toolkit/key_binding/bindings/basic.py
+++ b/src/prompt_toolkit/key_binding/bindings/basic.py
@@ -29,6 +29,16 @@ def if_no_repeat(event: E) -> bool:
     return not event.is_repeat
 
 
+@Condition
+def has_text_before_cursor() -> bool:
+    return bool(get_app().current_buffer.text)
+
+
+@Condition
+def in_quoted_insert() -> bool:
+    return get_app().quoted_insert
+
+
 def load_basic_bindings() -> KeyBindings:
     key_bindings = KeyBindings()
     insert_mode = vi_insert_mode | emacs_insert_mode
@@ -171,10 +181,6 @@ def load_basic_bindings() -> KeyBindings:
 
     # CTRL keys.
 
-    @Condition
-    def has_text_before_cursor() -> bool:
-        return bool(get_app().current_buffer.text)
-
     handle("c-d", filter=has_text_before_cursor & insert_mode)(
         get_by_name("delete-char")
     )
@@ -239,10 +245,6 @@ def load_basic_bindings() -> KeyBindings:
         data = data.replace("\r", "\n")
 
         event.current_buffer.insert_text(data)
-
-    @Condition
-    def in_quoted_insert() -> bool:
-        return get_app().quoted_insert
 
     @handle(Keys.Any, filter=in_quoted_insert, eager=True)
     def _insert_text(event: E) -> None:

--- a/src/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/src/prompt_toolkit/key_binding/bindings/emacs.py
@@ -33,6 +33,11 @@ __all__ = [
 E = KeyPressEvent
 
 
+@Condition
+def is_returnable() -> bool:
+    return get_app().current_buffer.is_returnable
+
+
 def load_emacs_bindings() -> KeyBindingsBase:
     """
     Some e-macs extensions.
@@ -141,10 +146,6 @@ def load_emacs_bindings() -> KeyBindingsBase:
         argument, ignore this.
         """
         event.app.key_processor.arg = "-"
-
-    @Condition
-    def is_returnable() -> bool:
-        return get_app().current_buffer.is_returnable
 
     # Meta + Enter: always accept input.
     handle("escape", "enter", filter=insert_mode & is_returnable)(

--- a/src/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/src/prompt_toolkit/key_binding/bindings/emacs.py
@@ -38,6 +38,11 @@ def is_returnable() -> bool:
     return get_app().current_buffer.is_returnable
 
 
+@Condition
+def is_arg() -> bool:
+    return get_app().key_processor.arg == "-"
+
+
 def load_emacs_bindings() -> KeyBindingsBase:
     """
     Some e-macs extensions.
@@ -139,7 +144,7 @@ def load_emacs_bindings() -> KeyBindingsBase:
         if event._arg is None:
             event.append_to_arg_count("-")
 
-    @handle("-", filter=Condition(lambda: get_app().key_processor.arg == "-"))
+    @handle("-", filter=is_arg)
     def _dash(event: E) -> None:
         """
         When '-' is typed again, after exactly '-' has been given as an


### PR DESCRIPTION
Reference: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1835
`Never/Always` is cached in `prompt_toolkit.filters.utils._bool_to_filter`, and if it is the first condition, it will hold the filter and cannot be freed.

The inline condition filter will have a different ID after the parent function is called (a new PromptSession is created). It will be cached by some global condition filter (e.g., is_searching), causing the cached size to increase and never be freed.