### PR TITLE
Remove Windows Terminal Recommendations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,6 @@ It's worth noting that the implementation is a "best effort of what is
 possible". Both Unix and Windows terminals have their limitations. But in
 general, the Unix experience will still be a little better.
 
-For Windows, it's recommended to use either `cmder
-<http://cmder.net/>`_ or `conemu <https://conemu.github.io/>`_.
 
 Getting started
 ***************


### PR DESCRIPTION
Closes #1816.

As commented by @jonathanslenders [here](https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1646#issuecomment-1160093611), we no longer need to recommend cmder/conemu. As a bonus, this also removes the link to a shady financial services site, which was presumably added by accident or has changed over time.