### PR TITLE
Expand type definition for filename

### DIFF
--- a/docs/pages/full_screen_apps.rst
+++ b/docs/pages/full_screen_apps.rst
@@ -358,7 +358,7 @@ As said earlier, a :class:`~prompt_toolkit.layout.Window` is a
 
 .. note::
 
-    Basically, windows are the leafs in the tree structure that represent the UI.
+    Basically, windows are the leaves in the tree structure that represent the UI.
 
 A :class:`~prompt_toolkit.layout.Window` provides a "view" on the
 :class:`~prompt_toolkit.layout.UIControl`, which provides lines of content. The

--- a/src/prompt_toolkit/history.py
+++ b/src/prompt_toolkit/history.py
@@ -259,7 +259,7 @@ class FileHistory(History):
     :class:`.History` class that stores all strings in a file.
     """
 
-    def __init__(self, filename: str) -> None:
+    def __init__(self, filename: str | os.PathLike) -> None:
         self.filename = filename
         super().__init__()
 


### PR DESCRIPTION
`FileHistory.filename` is currently hinted as `str`.

It is used by `open()` and `os.path.exists()`.  `os.path.exists()` supports `os.PathLike` [since 3.6](https://docs.python.org/3/library/os.path.html#os.path.exists)﻿

Therefore, the type hint should be expanded to `Union[str, os.PathLike]`.
