### PR TITLE
Address some typos in the tutorial pages

### DIFF
--- a/docs/pages/full_screen_apps.rst
+++ b/docs/pages/full_screen_apps.rst
@@ -391,7 +391,7 @@ A :class:`~prompt_toolkit.layout.processors.Processor` operates on individual
 lines. Basically, it takes a (formatted) line and produces a new (formatted)
 line.
 
-Some build-in processors:
+Some built-in processors:
 
 +----------------------------------------------------------------------------+-----------------------------------------------------------+
 | Processor                                                                  | Usage:                                                    |

--- a/docs/pages/progress_bars.rst
+++ b/docs/pages/progress_bars.rst
@@ -237,7 +237,7 @@ printing text possible while the progress bar is displayed. This ensures that
 printing happens above the progress bar.
 
 Further, when "x" is pressed, we set a cancel flag, which stops the progress.
-It would also be possible to send `SIGINT` to the mean thread, but that's not
+It would also be possible to send `SIGINT` to the main thread, but that's not
 always considered a clean way of cancelling something.
 
 In the example above, we also display a toolbar at the bottom which shows the


### PR DESCRIPTION
This commit will fix a couple of typos I noticed while reading through the tutorials.