### PR TITLE
Fix compatibility when SIGINT handler is installed by non-Python

### DIFF
--- a/src/prompt_toolkit/application/application.py
+++ b/src/prompt_toolkit/application/application.py
@@ -1621,5 +1621,6 @@ def _restore_sigint_from_ctypes() -> Generator[None, None, None]:
     try:
         yield
     finally:
-        signal.signal(signal.SIGINT, sigint)
+        if sigint is not None:
+            signal.signal(signal.SIGINT, sigint)
         pythonapi.PyOS_setsig(signal.SIGINT, sigint_os)


### PR DESCRIPTION
When a native (Rust, C) program installs SIGINT handler and calls into Python, `signal.getsignal` can return `None`, which is not a valid value for the 2nd parameter of `signal.signal`. Fix it by checking `None` explicitly.