### PR TITLE
drop python<=3.7 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +37,7 @@ jobs:
       - name: Tests
         run: |
           coverage run -m pytest
-      - if: "matrix.python-version != '3.7'"
-        name: Mypy
+      - name: Mypy
         # Check whether the imports were sorted correctly.
         # When this fails, please run ./tools/sort-imports.sh
         run: |

--- a/setup.py
+++ b/setup.py
@@ -30,17 +30,13 @@ setup(
     package_dir={"": "src"},
     package_data={"prompt_toolkit": ["py.typed"]},
     install_requires=["wcwidth"],
-    # We require Python 3.7, because we need:
-    # - Context variables - PEP 567
-    # - `asyncio.run()`
-    python_requires=">=3.7.0",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/src/prompt_toolkit/layout/screen.py
+++ b/src/prompt_toolkit/layout/screen.py
@@ -169,7 +169,7 @@ class Screen:
 
         #: Escape sequences to be injected.
         self.zero_width_escapes: defaultdict[int, defaultdict[int, str]] = defaultdict(
-            lambda: defaultdict(lambda: "")
+            lambda: defaultdict(str)
         )
 
         #: Position of the cursor.

--- a/src/prompt_toolkit/layout/utils.py
+++ b/src/prompt_toolkit/layout/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, List, TypeVar, cast, overload
 from prompt_toolkit.formatted_text.base import OneStyleAndTextTuple
 
 if TYPE_CHECKING:
-    from typing_extensions import SupportsIndex
+    from typing import SupportsIndex
 
 __all__ = [
     "explode_text_fragments",


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgrade --py3.8-plus`.