### PR TITLE
Fix ValueError: I/O operation on closed file.

### DIFF
--- a/src/prompt_toolkit/application/current.py
+++ b/src/prompt_toolkit/application/current.py
@@ -53,7 +53,7 @@ class AppSession:
 
     @property
     def input(self) -> Input:
-        if self._input is None:
+        if self._input is None or self._input.closed:
             from prompt_toolkit.input.defaults import create_input
 
             self._input = create_input()
@@ -61,7 +61,7 @@ class AppSession:
 
     @property
     def output(self) -> Output:
-        if self._output is None:
+        if self._output is None or (self._output.stdout and self._output.stdout.closed):
             from prompt_toolkit.output.defaults import create_output
 
             self._output = create_output()


### PR DESCRIPTION
Hello Jonathan!

I found such a problem: 
```
from prompt_toolkit import print_formatted_text
from pytest import CaptureFixture

def test_1(capsys: CaptureFixture[str]) -> None:
    print_formatted_text("TEST")


def test_2() -> None:
    print_formatted_text("TEST")
```

that ends up with:

```
py/lib/python3.11/site-packages/prompt_toolkit/shortcuts/utils.py:164: in print_formatted_text
    render()
py/lib/python3.11/site-packages/prompt_toolkit/shortcuts/utils.py:139: in render
    renderer_print_formatted_text(
py/lib/python3.11/site-packages/prompt_toolkit/renderer.py:813: in print_formatted_text
    output.flush()
py/lib/python3.11/site-packages/prompt_toolkit/output/plain_text.py:59: in flush
    flush_stdout(self.stdout, data)
py/lib/python3.11/site-packages/prompt_toolkit/output/flush_stdout.py:33: ValueError
ValueError: I/O operation on closed file.
```

CaptureFixture closes the output stdout so I added checks they prevent such a case 