### PR TITLE
Make AppSession compatible with pytest's capsys fixture + docs.

### DIFF
--- a/docs/pages/advanced_topics/unit_testing.rst
+++ b/docs/pages/advanced_topics/unit_testing.rst
@@ -116,6 +116,21 @@ single fixture that does it for every test. Something like this:
             with create_app_session(input=pipe_input, output=DummyOutput()):
                 yield pipe_input
 
+For compatibility with pytest's ``capsys`` fixture, we have to create a new
+:class:`~prompt_toolkit.application.current.AppSession` for every test. This
+can be done in an autouse fixture. Pytest replaces ``sys.stdout`` with a new
+object in every test that uses ``capsys`` and the following will ensure that
+the new :class:`~prompt_toolkit.application.current.AppSession` will each time
+refer to the latest output.
+
+.. code:: python
+
+    from prompt_toolkit.application import create_app_session
+
+    @fixture(autouse=True, scope="function")
+    def _pt_app_session()
+        with create_app_session():
+            yield
 
 Type checking
 -------------

--- a/src/prompt_toolkit/application/current.py
+++ b/src/prompt_toolkit/application/current.py
@@ -147,11 +147,17 @@ def create_app_session(
     Like in the case of an Telnet/SSH server.
     """
     # If no input/output is specified, fall back to the current input/output,
-    # whatever that is.
+    # if there was one that was set/created for the current session.
+    # (Note that we check `_input`/`_output` and not `input`/`output`. This is
+    # because we don't want to accidently create a new input/output objects
+    # here and store it in the "parent" `AppSession`. Especially, when
+    # combining pytest's `capsys` fixture and `create_app_session`, sys.stdin
+    # and sys.stderr are patched for every test, so we don't want to leak
+    # those outputs object across `AppSession`s.)
     if input is None:
-        input = get_app_session().input
+        input = get_app_session()._input
     if output is None:
-        output = get_app_session().output
+        output = get_app_session()._output
 
     # Create new `AppSession` and activate.
     session = AppSession(input=input, output=output)


### PR DESCRIPTION
Successor of https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1878