### PR TITLE
Typo in Floats example

### DIFF
--- a/examples/full-screen/simple-demos/floats.py
+++ b/examples/full-screen/simple-demos/floats.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Horizontal split example.
+Floats example.
 """
 
 from prompt_toolkit.application import Application


### PR DESCRIPTION
This commit fixes a typo in the module docstring of the Floats example.