### PR TITLE
Word wrapping

### DIFF
--- a/examples/prompts/auto-completion/fuzzy-custom-completer.py
+++ b/examples/prompts/auto-completion/fuzzy-custom-completer.py
@@ -36,21 +36,28 @@ class ColorCompleter(Completer):
 def main():
     # Simple completion menu.
     print("(The completion menu displays colors.)")
-    prompt("Type a color: ", completer=FuzzyCompleter(ColorCompleter()))
-
-    # Multi-column menu.
-    prompt(
+    r = prompt(
         "Type a color: ",
         completer=FuzzyCompleter(ColorCompleter()),
         complete_style=CompleteStyle.MULTI_COLUMN,
     )
+    print(r)
+
+    # Multi-column menu.
+    r = prompt(
+        "Type a color: ",
+        completer=FuzzyCompleter(ColorCompleter()),
+        complete_style=CompleteStyle.MULTI_COLUMN,
+    )
+    print(r)
 
     # Readline-like
-    prompt(
+    r = prompt(
         "Type a color: ",
         completer=FuzzyCompleter(ColorCompleter()),
         complete_style=CompleteStyle.READLINE_LIKE,
     )
+    print(r)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I wanted to use word wrapping and saw #1648  so here’s a preliminary PR, to discuss what needs changing/rewording/testing. In short, I’ve added a second callback similar to `GetLinePrefix` that defines wrapping points. They return a tuple of:
1. wrap position (self-explanatory)
2. number of chars to remove. Typically to remove the whitespace that was wrapped.\* You can also return -1 to truncate the line.
3. continuation text: any formatted text to insert before the line break to indicate continuation. Typically a hyphen if breaking a word in 2, or a `⮠` in a code block to indicate a non-semantic break, etc.

A default wrapping function is provided to do word wrapping (and it can even be re-used and tuned for different purposes). It can be activated with `word_wrap=True` on windows. For actual hyphenation a user would have to provide their own function.

\* E.g. if you want to wrap the text `example wrapped text` on 7 columns, you either break before the first space and remove it, or before and then your next line starts with a space (which looks weird). On 15 columns you’d have a similar problem but either break as `example ` / `wrapped ` / `text` without character removal, or `example wrapped` / `text`, so allowing character removal is good for efficiency of justified text.