### PR TITLE
Update type definition for `words` argument

### DIFF
--- a/src/prompt_toolkit/completion/fuzzy_completer.py
+++ b/src/prompt_toolkit/completion/fuzzy_completer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Callable, Iterable, NamedTuple
+from typing import Callable, Iterable, NamedTuple, Sequence
 
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import FilterOrBool, to_filter
@@ -187,7 +187,7 @@ class FuzzyWordCompleter(Completer):
 
     def __init__(
         self,
-        words: list[str] | Callable[[], list[str]],
+        words: Sequence[str] | Callable[[], Sequence[str]],
         meta_dict: dict[str, str] | None = None,
         WORD: bool = False,
     ) -> None:

--- a/src/prompt_toolkit/completion/word_completer.py
+++ b/src/prompt_toolkit/completion/word_completer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Iterable, Mapping, Pattern
+from typing import Callable, Iterable, Mapping, Pattern, Sequence
 
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from prompt_toolkit.document import Document
@@ -33,7 +33,7 @@ class WordCompleter(Completer):
 
     def __init__(
         self,
-        words: list[str] | Callable[[], list[str]],
+        words: Sequence[str] | Callable[[], Sequence[str]],
         ignore_case: bool = False,
         display_dict: Mapping[str, AnyFormattedText] | None = None,
         meta_dict: Mapping[str, AnyFormattedText] | None = None,


### PR DESCRIPTION
The type definition permits `list[str] | Callable[[], list[str]]` however a tuple is valid too. Updating the type definition to use `Sequence[str] | Callable[[], Sequence[str]]` to allow using a tuple without errors