### PR TITLE
Fixes bug whereby read_only bool is called as a function

### DIFF
--- a/src/prompt_toolkit/filters/app.py
+++ b/src/prompt_toolkit/filters/app.py
@@ -371,7 +371,7 @@ def emacs_insert_mode() -> bool:
     if (
         app.editing_mode != EditingMode.EMACS
         or app.current_buffer.selection_state
-        or app.current_buffer.read_only()
+        or app.current_buffer.read_only
     ):
         return False
     return True


### PR DESCRIPTION
This is a simple bug fix to remedy the following issue:

```python
  File ".../site-packages/prompt_toolkit/filters/app.py", line 374, in emacs_insert_mode
    or app.current_buffer.read_only()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Exception 'bool' object is not callable
```

It would appear to be a simple typo, calling the boolean `read_only` property as if it were a function.