### PR TITLE
Try to run ruff and typo only on 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,9 +30,13 @@ jobs:
           python -m pip install . ruff typos coverage codecov mypy pytest readme_renderer types-contextvars asyncssh
           pip list
       - name: Ruff
+        if: ${{ matrix.python-version == '3.13' }}
         run: |
           ruff check .
           ruff format --check .
+      - name: Typos
+        if: ${{ matrix.python-version == '3.13'" && always() }}
+        run: |
           typos .
       - name: Tests
         run: |


### PR DESCRIPTION
There is no need to run N times.

This in particular means that we can still see from a glance the tests are passing on older python.

I also try to run typo regardless of wether ruff check and formatting passes, which hopefully avoid one iteration of fix, push and CI failing.