### PR TITLE
Re-add project URLs after migration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
     "wcwidth",
 ]
 
+[project.urls]
+homepage = "https://github.com/prompt-toolkit/python-prompt-toolkit"
+source = "https://github.com/prompt-toolkit/python-prompt-toolkit"
+documentation = "https://python-prompt-toolkit.readthedocs.io/en/stable/"
+
 [tool.ruff]
 target-version = "py37"
 lint.select = [


### PR DESCRIPTION
Following spec:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

The previous URL was removed in https://github.com/prompt-toolkit/python-prompt-toolkit/commit/88a011ccde71fe1df6b8e873801d1276859e9e70 which has removed all URLs from PyPI.

The new format allows listing of different types of URL so have added the most common ones.