### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "prompt_toolkit"
+license.text = "BSD-3-Clause"
 version = "3.0.51"  # Also update in `docs/conf.py`.
 description="Library for building powerful interactive command lines in Python"
 readme = "README.rst"
@@ -7,7 +8,6 @@ authors = [{ name = "Jonathan Slenders" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Prepare for PEP 639 license expressions.

Setuptools `v77` added full support for it. However that version requires Python `>=3.9`. Until `3.8` is dropped, the next best thing would be to use the legacy `license.text` field with the correct SPDX license identifier.

All that's needed later would be
```diff
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
```

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
https://spdx.org/licenses/BSD-3-Clause.html