### PR TITLE
Reduce default ttimeoutlen

### DIFF
--- a/src/prompt_toolkit/application/application.py
+++ b/src/prompt_toolkit/application/application.py
@@ -289,7 +289,7 @@ class Application(Generic[_AppResult]):
         #: after "\x1b". This little timer will consider "\x1b" to be escape if
         #: nothing did follow in this time span.
         #: This seems to work like the `ttimeoutlen` option in Vim.
-        self.ttimeoutlen = 0.5  # Seconds.
+        self.ttimeoutlen = 0.05  # Seconds.
 
         #: Like Vim's `timeoutlen` option. This can be `None` or a float.  For
         #: instance, suppose that we have a key binding AB and a second key


### PR DESCRIPTION
This timeout is for delay between two machine inputs, not human inputs, so there is no need for it to be so long. with the reduced value, bindings on 'escape' are now reasonably usable.

note: running pytest I saw that two tests failed, but the same ones fail for me before my commit as well.