### PR TITLE
Add an LLM-based AutoSuggester

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,14 @@ dependencies = [
     "wcwidth",
 ]
 
+[project.optional-dependencies]
+"llm" = [
+      # additional dependencies needed to use LLM auto-suggesters and completers
+      "langchain",
+      "langchain_core",
+      "PyEnchant"
+]
+
 [tool.ruff]
 target-version = "py37"
 lint.select = [

--- a/src/prompt_toolkit/contrib/auto_suggest/__init__.py
+++ b/src/prompt_toolkit/contrib/auto_suggest/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .llmsuggest import LLMSuggest
+
+__all__ = ["LLMSuggest"]

--- a/src/prompt_toolkit/contrib/auto_suggest/llmsuggest.py
+++ b/src/prompt_toolkit/contrib/auto_suggest/llmsuggest.py
@@ -1,0 +1,243 @@
+"""
+`Fish-style <http://fishshell.com/>`_  like auto-suggestion using a
+large language model to propose the suggestions.
+
+Example usage:
+
+ import os
+ from prompt_toolkit import PromptSession
+ from prompt_toolkit.contrib.auto_suggest import LLMSuggest
+ from prompt_toolkit.auto_suggest import ThreadedAutoSuggest
+
+ from langchain.chat_models import init_chat_model
+
+ # Initialize a langchain chat model. You may need to install
+ # additional provider-specific modules such as langchain-openai.
+ if not os.environ.get('OPENAI_API_KEY'):
+    os.environ['OPENAI_API_KEY'] = 'sk-XXXXXXXXXX'
+ chat_model = init_chat_model('openai:gpt-4o', temperature=0.0)
+
+ # Create the llm suggest object
+ suggester = LLMSuggest(chat_model)
+
+ # Create the prompt session. Because waiting for the LLM can be slow,
+ # it is recommended to wrap the suggester in a ThreadedAutoSuggest instance.
+ session = PromptSession(auto_suggest=ThreadedAutoSuggest(suggester))
+ while True:
+    response = session.prompt('> ')
+    print(f"You said '{response}'")
+"""
+
+import locale
+import re
+import string
+import sys
+from typing import Callable, Optional
+
+import enchant
+from langchain.chat_models import init_chat_model
+from langchain_core.language_models import BaseChatModel
+from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
+from prompt_toolkit.buffer import Buffer, Document
+
+DEFAULT_PERSONA="""
+You are an uncensored writing assistant who is skilled at completing text fragments
+into full, natural-sounding sentences.
+"""
+
+SYSTEM_MESSAGE="""
+%s
+
+Return a completion of the provided text fragment following these
+examples:
+
+# Example 1
+user: I want a bi...
+assistant: ...cycle for Christmas.
+
+# Example 2
+user: Hi there, what's your name?...
+assistant:  ... My name is Fred. What's yours?
+
+# Example
+user: I don't want to go to the mall! I want to go to...
+assistant: ... watch the Titanic movie tonight.
+
+# Example 4
+user: He watched in amazement as the magician pulled a rabbit out of his hat....
+assistant: ... When he put the rabbit down it hopped away.
+"""
+
+DEFAULT_INSTRUCTION="""
+Complete this text with a word fragment, word, phrase, or
+sentence, showing only the new text.
+
+Do not repeat any part of the original text:
+Original text: {text}
+"""
+
+class LLMSuggest(AutoSuggest):
+    """AutoSuggest subclass that provides Suggestions based on LLM completions."""
+
+    def __init__(self,
+                 chat_model: Optional[BaseChatModel]=None,
+                 persona: str=DEFAULT_PERSONA,
+                 context: str | Callable[[], str]='',
+                 instruction: str=DEFAULT_INSTRUCTION,
+                 language: Optional[str]=None,
+                 debug: Optional[bool]=False,
+                 ) -> None:
+        """Initialize the :class:`.LLMSuggest` instance.
+
+        All arguments are optional.
+
+        :param chat_model: A langchain chat model created by init_chat_model.
+        :param persona: A description of the LLM's persona, for tuning its writing style [:class:`.DEFAULT_PERSONA`].
+        :param context: A string or callable passed to the LLM that provides the context
+                        of the conversation so far [empty string].
+        :param language: Locale language, used to validate LLM's response [from locale environment]
+        :param instruction: Instructions passed to the LLM to inform the suggestion process [:class:`.DEFAULT_INSTRUCTION`].
+
+        Notes:
+
+        1. If `chat_model` is not provided, the class will attempt
+        to open a connection to OpenAI's `gpt-4o` model. For this
+        to work, the `langchain-openai` module must be installed,
+        and the `OPENAI_API_KEY` environment variable must be set
+        to a valid key.
+
+        2. The `persona` argument can be used to adjust the writing
+        style of the LLM. For example: "You are a python coder skilled
+        at completing code fragments." Or try "You are a romance
+        novelist who writes in a florid overwrought style."
+
+        3. `language`: Some LLMs are better than others at providing
+        completions of partial words. We use the `PyEnchant` module
+        to determine whether a proposed completion is the continuation
+        of a word or starts a new word. This argument selects the
+        preferred language for the dictionary, such as "en_US". If
+        not provided, the module will select the language specified in
+        the system's locale.
+
+        4. `instruction` lets you change the instruction that is
+        passed to the LLM to show it how to complete the partial
+        prompt text.  The default is :class:`.DEFAULT_INSTRUCTION`,
+        and must contain the string placeholder "{text}" which will be
+        replaced at runtime with the partial prompt text.
+
+        5. The `context` argument provides the ability to pass
+        additional textual context to the LLM suggester in addition to
+        the text that is already in the current prompt buffer. It can
+        be either a Callable that returns a string, or a static
+        string. You can use this to give the LLM access to textual
+        information that is contained in a different buffer, or to
+        provide the LLM with supplementary context such as the time of
+        day, weather report, or the results of a web search.
+
+        """
+        super().__init__()
+        self.system = SYSTEM_MESSAGE
+        self.instruction = instruction
+        self.persona = persona
+        self.dictionary = enchant.Dict(language or locale.getdefaultlocale()[0])
+        self.context = context
+        self.chat_model = chat_model or init_chat_model('openai:gpt-4o', temperature=0.0)
+
+    def _capfirst(self, s:str) -> str:
+        return s[:1].upper() + s[1:]
+
+    def _format_sys(self) -> str:
+        """Format the system string."""
+        system = self.system % self.persona
+        if context := self.get_context():
+            system += "\nTo guide your completion, here is the text so far:\n"
+            system += context
+        return system
+
+    def set_context(self, context: Callable[[], str] | str) -> None:
+        """
+        Set the additional context that the LLM is exposed to.
+
+        :param context: A string or a Callable that returns a string.
+
+        This provides additional textual context to guide the suggester's
+        response.
+        """
+        self.context = context
+
+    def get_context(self) -> Callable[[], str] | str:
+        """Retrieve the additional context passed to the LLM."""
+        return self.context if isinstance(self.context, str) else self.context()
+
+    def clear_context(self) -> None:
+        """Clear the additional context passed to the LLM."""
+        self.context = ''
+
+    def get_suggestion(self,
+                       buffer: Buffer,
+                       document: Document) -> Optional[Suggestion]:
+        """
+        Return a Suggestion instance based on the LLM's completion of the current text.
+
+        :param buffer: The current `Buffer`.
+        :param document: The current `Document`.
+
+        Under various circumstances, the LLM may return no usable suggestions, in which
+        case the call returns None.
+        """
+        text = document.text
+        if not text or len(text) < 3:
+            return None
+        messages = [
+            {"role": "system", "content": self._format_sys()},
+            {"role": "human", "content": self.instruction.format(text=text)},
+        ]
+
+        try:
+            response = self.chat_model.invoke(messages)
+            suggestion = str(response.content)
+
+            # Remove newlines or '...' sequences that the llm may have added
+            suggestion = suggestion.replace('\n', '')
+            suggestion = suggestion.replace('...', '')
+            suggestion = suggestion.rstrip()
+
+            # If LLM echoed the original text back, then remove it
+            if suggestion.startswith(text.rstrip()):
+                suggestion = suggestion[len(text):]
+
+            # Handle punctuation between the text and the suggestion
+            if suggestion.startswith(tuple(string.punctuation)):
+                return Suggestion(suggestion)
+            if text.endswith("'"):
+                return Suggestion(suggestion.lstrip())
+
+            # Adjust capitalization the beginnings of new sentences.
+            if re.search(r'[.?!:]\s*$',text):
+                suggestion = self._capfirst(suggestion.lstrip())
+
+            # Get the last word of the existing text and the first word of the suggestion
+            match = re.search(r'(\w+)\W*$', text)
+            last_word_of_text = match.group(1) if match else ''
+
+            match = re.search(r'^\s*(\w+)', suggestion)
+            first_word_of_suggestion = match.group(1) if match else ''
+
+            # Add or remove spaces based on whether concatenation will form a word
+            if suggestion.startswith(' '):
+                suggestion = suggestion.lstrip() if text.endswith(' ') else suggestion
+            elif self.dictionary.check(last_word_of_text + first_word_of_suggestion) and not text.endswith(' '):
+                suggestion = suggestion.lstrip()
+            elif not text.endswith(' '):
+                suggestion = ' ' + suggestion
+
+            # Add space after commas and semicolons
+            if re.search(r'[,;]$',text):
+                suggestion = ' ' + suggestion.lstrip()
+
+            return Suggestion(suggestion)
+
+        except Exception as e:
+            print(e)
+            pass
+        return None

--- a/src/prompt_toolkit/contrib/auto_suggest/llmsuggest.py
+++ b/src/prompt_toolkit/contrib/auto_suggest/llmsuggest.py
@@ -31,12 +31,12 @@ Example usage:
 import locale
 import re
 import string
-import sys
 from typing import Callable, Optional
 
 import enchant
 from langchain.chat_models import init_chat_model
 from langchain_core.language_models import BaseChatModel
+
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 from prompt_toolkit.buffer import Buffer, Document
 
@@ -82,7 +82,7 @@ class LLMSuggest(AutoSuggest):
     def __init__(self,
                  chat_model: Optional[BaseChatModel]=None,
                  persona: str=DEFAULT_PERSONA,
-                 context: str | Callable[[], str]='',
+                 context: str | Callable[[], str]="",
                  instruction: str=DEFAULT_INSTRUCTION,
                  language: Optional[str]=None,
                  debug: Optional[bool]=False,
@@ -141,7 +141,7 @@ class LLMSuggest(AutoSuggest):
         self.persona = persona
         self.dictionary = enchant.Dict(language or locale.getdefaultlocale()[0])
         self.context = context
-        self.chat_model = chat_model or init_chat_model('openai:gpt-4o', temperature=0.0)
+        self.chat_model = chat_model or init_chat_model("openai:gpt-4o", temperature=0.0)
 
     def _capfirst(self, s:str) -> str:
         return s[:1].upper() + s[1:]
@@ -171,7 +171,7 @@ class LLMSuggest(AutoSuggest):
 
     def clear_context(self) -> None:
         """Clear the additional context passed to the LLM."""
-        self.context = ''
+        self.context = ""
 
     def get_suggestion(self,
                        buffer: Buffer,
@@ -198,8 +198,8 @@ class LLMSuggest(AutoSuggest):
             suggestion = str(response.content)
 
             # Remove newlines or '...' sequences that the llm may have added
-            suggestion = suggestion.replace('\n', '')
-            suggestion = suggestion.replace('...', '')
+            suggestion = suggestion.replace("\n", "")
+            suggestion = suggestion.replace("...", "")
             suggestion = suggestion.rstrip()
 
             # If LLM echoed the original text back, then remove it
@@ -213,31 +213,30 @@ class LLMSuggest(AutoSuggest):
                 return Suggestion(suggestion.lstrip())
 
             # Adjust capitalization the beginnings of new sentences.
-            if re.search(r'[.?!:]\s*$',text):
+            if re.search(r"[.?!:]\s*$",text):
                 suggestion = self._capfirst(suggestion.lstrip())
 
             # Get the last word of the existing text and the first word of the suggestion
-            match = re.search(r'(\w+)\W*$', text)
-            last_word_of_text = match.group(1) if match else ''
+            match = re.search(r"(\w+)\W*$", text)
+            last_word_of_text = match.group(1) if match else ""
 
-            match = re.search(r'^\s*(\w+)', suggestion)
-            first_word_of_suggestion = match.group(1) if match else ''
+            match = re.search(r"^\s*(\w+)", suggestion)
+            first_word_of_suggestion = match.group(1) if match else ""
 
             # Add or remove spaces based on whether concatenation will form a word
-            if suggestion.startswith(' '):
-                suggestion = suggestion.lstrip() if text.endswith(' ') else suggestion
-            elif self.dictionary.check(last_word_of_text + first_word_of_suggestion) and not text.endswith(' '):
+            if suggestion.startswith(" "):
+                suggestion = suggestion.lstrip() if text.endswith(" ") else suggestion
+            elif self.dictionary.check(last_word_of_text + first_word_of_suggestion) and not text.endswith(" "):
                 suggestion = suggestion.lstrip()
-            elif not text.endswith(' '):
-                suggestion = ' ' + suggestion
+            elif not text.endswith(" "):
+                suggestion = " " + suggestion
 
             # Add space after commas and semicolons
-            if re.search(r'[,;]$',text):
-                suggestion = ' ' + suggestion.lstrip()
+            if re.search(r"[,;]$",text):
+                suggestion = " " + suggestion.lstrip()
 
             return Suggestion(suggestion)
 
-        except Exception as e:
-            print(e)
+        except Exception:
             pass
         return None

--- a/tests/test_llmsuggest.py
+++ b/tests/test_llmsuggest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+import re
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
+
+try:
+    from langchain_core.messages import AIMessage, BaseMessage
+    from prompt_toolkit.contrib.auto_suggest import LLMSuggest
+    module_loaded = True
+except ModuleNotFoundError:
+    module_loaded = False
+
+     # LLM input              LLM output            Expected input + suggestion
+test_data = [
+    ("The quick brown",      " fox jumps over",    "The quick brown fox jumps over"),
+    ("The quick brown ",     "fox jumps over",     "The quick brown fox jumps over"),
+    ("The quick br",         "own fox jumps over", "The quick brown fox jumps over"),
+    ("The quick br ",        "fox jumps over",     "The quick br fox jumps over"),
+    ("The quick brown fox.", " he jumped over",    "The quick brown fox. He jumped over"),
+    ("The quick brown fox",  "The quick brown fox jumps over", "The quick brown fox jumps over"),
+    ("The quick brown fox,",  "jumped over",       "The quick brown fox, jumped over"),
+    ("The quick brown fox'",  " s fence",          "The quick brown fox's fence"),
+    ("The quick brown fox'",  "s fence",           "The quick brown fox's fence"),
+]
+
+
+class MockModel:
+    def invoke(self, messages: list[dict[str, str]]) -> BaseMessage:
+        # find the original text using a regex
+        human_message = messages[1]["content"]
+        if match := re.search(r"Original text: (.+)",human_message):
+            original_text = match.group(1)
+            for input, output, completion in test_data:
+                if original_text == input:
+                    return AIMessage(content=output)
+        return AIMessage(content="")
+
+@pytest.fixture
+def chat_model():
+    return MockModel()
+
+@pytest.fixture
+def suggester(chat_model) -> LLMSuggest:
+    return LLMSuggest(chat_model, language='en_US')
+
+@pytest.fixture
+def buffer() -> Buffer:
+    return Buffer()
+
+@pytest.mark.parametrize(
+    "input,output,expected_completion",
+    test_data
+)
+@pytest.mark.skipif(not module_loaded, reason="The langchain, langchain_core and PyEnchant modules need to be installed to run these tests")
+def test_suggest(suggester, buffer, input, output, expected_completion):
+    document = Document(text=input)
+    suggestion = suggester.get_suggestion(buffer, document)
+    completion = input + suggestion.text
+    assert completion == expected_completion


### PR DESCRIPTION
**Description**

This PR implements a new `LLMSuggest` AutoSuggester module which connects to a remote or locally-hosted Large Language Model (LLM) to suggest completions of words, phrases or sentences. It can be used with any `Buffer` class that accepts the `auto_suggest` argument. 

This video shows the autosuggester in action, when using a local Ollama instance. It also works with OpenAI, Anthropic, and other popular commercial LLM services.

https://github.com/user-attachments/assets/0ca3cab8-524c-4443-be35-ae7eec990d03

**Installation**

`LLMSuggest` introduces requirements for the `langchain`, `langchain_core` and `PyEnchant` modules. These can be installed with pip by specifying the `llm` optional dependencies when installing `prompt_toolkit`.
```
# From the project root.
pip install .[llm]

# When and if this PR is released to pypi:
pip install prompt_toolkit[llm]
``` 

Together, these three dependencies plus their own requirements (such as pydantic) will increase the size of an installed `prompt_toolkit` by an additional  54M.

**Testing**

This module comes with a unit test that assesses the module's ability to join the output from the LLM with the user's prompt properly. The test uses a mock LLM chat class to avoid the additional setup needed, and will be skipped  if the optional dependencies are not installed.
 
To run the unit test:

```
# from within the repo root
pytest  tests/test_llmsuggest.py
```

**Usage**

Basic usage is quite straightforward. Just create an instance of `LLMSuggest`, wrap it in a `ThreadedAutoSuggest` wrapper, and pass the instance to the `auto_suggest` argument of a `Prompt`, `PromptSession`, `TextArea`, or any of the lower-level `Buffer`-derived classes that accept this argument. Suggestions appear as you type. Accept the entire suggestion by pressing `^E` or `right-arrow`, or accept the next word using `alt-F`. These key bindings can be changed as described in the `AutoSuggest` reference manual.

Below is a basic script that uses the default ChatGPT 4o-mini "free tier" for its suggestions. 

```
from prompt_toolkit import prompt
from prompt_toolkit.contrib.auto_suggest import LLMSuggest
from prompt_toolkit.auto_suggest import ThreadedAutoSuggest

suggester = LLMSuggest()
suggester = ThreadedAutoSuggest(suggester)  # wrap to avoid delays while typing

while True:
   response = prompt('> ', auto_suggest=suggester)
   print(f"You said '{response}'")

```
For this to work, you must have an OpenAI account, and a valid API key stored in the environment variable `OPENAI_API_KEY` . See [platform.openai.com](https://platform.openai.com) for details. 

To use a different LLM model, initialize the suggester with an instantiated langchain chat model. This example shows how to use a `llama3` model running on a local [Ollama](https://ollama.com) server:

```
from prompt_toolkit import prompt
from prompt_toolkit.contrib.auto_suggest import LLMSuggest
from prompt_toolkit.auto_suggest import ThreadedAutoSuggest
# new part starts here
from langchain.chat_models import init_chat_model  

model = init_chat_model('ollama:llama3', temperature=0.0)
suggester = LLMSuggest(chat_model=model)
suggester = ThreadedAutoSuggest(suggester)  

# everything below is the same
```
For this to work, you must have the optional `langchain-ollama` module installed, using `pip install langchain-ollama`. 

After installing additional `langchain` [chat modules](https://python.langchain.com/docs/integrations/chat/), you can use many other backend LLMs, including  Claude, Groq, Perplexity and Gemini. 

**Customization**

Several optional constructor arguments allow you to adjust the behavior of the autosuggester. The `persona` argument allows you to adjust the style and tone of the completions. Compare the suggestions you get from these two versions:

```
suggester = LLMSuggest(persona='You are a copy editor for a technical journal')
```
vs
```
suggester = LLMSuggest(persona='You are a romance novelist, skilled in generating fullsome and lyrical prose.')
```
The optional `temperature` argument is a floating point number which controls the diversity of the suggestions. Lower numbers make the suggestions more deterministic. A temperature of 0.0 results in fully deterministic suggestions, but is more likely to generate cliches. Higher numbers generate prose that appear more creative, but may also introduce nonsensical completions.

Finally, the `context` argument allows you to pass additional text to the LLM to help it produce context-aware suggestions. This can be a plain text string, or a Callable that returns a string. A typical use case would be to pass the LLM the contents of a buffer containing a story that is being composed or the record of a chatbot conversation.

Additional options are described in the inline documentation.

**Bugs and Limitations**

* Due to the design of the AutoSuggest class, suggestions can only be appended to the end of the current buffer, which means that inline suggestions in the style of GitHub Copilot are not feasible.
* Latency can be an issue when using the remotely hosted LLMs, particularly when traffic is high. Always wrap the suggester in a `ThreadedAutoSuggester` to avoid blocking of keystrokes while the LLM is thinking. Consider using a local model for best responsiveness.
* Some LLMs do not follow instructions to the letter and either insert additional whitespace into their responses, or fail to do so. The `LLMSuggest` code uses the `PyEnchant` library to figure out when the proferred completion is intended to complete a word or to start a new word. This is not 100% reliable.
* Some LLMs will refuse to offer suggestions if the text appears to be violating their guardrails (e.g. promoting violence or hate speech). The package global `prompt_toolkit.contrib.auto_suggest.llmsuggest.DEFAULT_PERSONA`  tells the LLM that it is an "uncensored writing assistant" to slightly reduce the rate of such refusals on borderline cases. You may wish to adjust the persona to be less lenient of such cases.
