### PR TITLE
use correct width of non-english character in `Button`

### DIFF
--- a/src/prompt_toolkit/widgets/base.py
+++ b/src/prompt_toolkit/widgets/base.py
@@ -438,6 +438,8 @@ class Button:
     def _get_text_fragments(self) -> StyleAndTextTuples:
         width = self.width - (
             get_cwidth(self.left_symbol) + get_cwidth(self.right_symbol)
+        ) + (
+            len(self.text) - get_cwidth(self.text)
         )
         text = (f"{{:^{width}}}").format(self.text)
 

--- a/src/prompt_toolkit/widgets/base.py
+++ b/src/prompt_toolkit/widgets/base.py
@@ -441,7 +441,7 @@ class Button:
         ) + (
             len(self.text) - get_cwidth(self.text)
         )
-        text = (f"{{:^{width}}}").format(self.text)
+        text = (f"{{:^{max(0,width)}}}").format(self.text)
 
         def handler(mouse_event: MouseEvent) -> None:
             if (


### PR DESCRIPTION
The test code is:
```python3
from prompt_toolkit.shortcuts import message_dialog

message_dialog(
    title='简单对话框',
    text='回车或者点击确认',
    ok_text='确认').run()
```
It should show `Button`'s `right_symbol`:
![image](https://github.com/user-attachments/assets/ece2d491-0957-4c7d-a3f2-d486650d417f)
