### PR TITLE
ANSI dim text styling

### DIFF
--- a/src/prompt_toolkit/formatted_text/ansi.py
+++ b/src/prompt_toolkit/formatted_text/ansi.py
@@ -37,6 +37,7 @@ class ANSI:
         self._color: str | None = None
         self._bgcolor: str | None = None
         self._bold = False
+        self._dim = False
         self._underline = False
         self._strike = False
         self._italic = False
@@ -153,8 +154,8 @@ class ANSI:
                 self._bgcolor = _bg_colors[attr]
             elif attr == 1:
                 self._bold = True
-            # elif attr == 2:
-            #   self._faint = True
+            elif attr == 2:
+                self._dim = True
             elif attr == 3:
                 self._italic = True
             elif attr == 4:
@@ -171,6 +172,7 @@ class ANSI:
                 self._strike = True
             elif attr == 22:
                 self._bold = False  # Normal intensity
+                self._dim = False
             elif attr == 23:
                 self._italic = False
             elif attr == 24:
@@ -188,6 +190,7 @@ class ANSI:
                 self._color = None
                 self._bgcolor = None
                 self._bold = False
+                self._dim = False
                 self._underline = False
                 self._strike = False
                 self._italic = False
@@ -232,6 +235,8 @@ class ANSI:
             result.append("bg:" + self._bgcolor)
         if self._bold:
             result.append("bold")
+        if self._dim:
+            result.append("dim")
         if self._underline:
             result.append("underline")
         if self._strike:

--- a/src/prompt_toolkit/output/vt100.py
+++ b/src/prompt_toolkit/output/vt100.py
@@ -257,7 +257,7 @@ _256_colors = _256ColorCache()
 class _EscapeCodeCache(Dict[Attrs, str]):
     """
     Cache for VT100 escape codes. It maps
-    (fgcolor, bgcolor, bold, underline, strike, reverse) tuples to VT100
+    (fgcolor, bgcolor, bold, underline, strike, italic, blink, reverse, hidden, dim) tuples to VT100
     escape sequences.
 
     :param true_color: When True, use 24bit colors instead of 256 colors.
@@ -277,6 +277,7 @@ class _EscapeCodeCache(Dict[Attrs, str]):
             blink,
             reverse,
             hidden,
+            dim,
         ) = attrs
         parts: list[str] = []
 
@@ -284,6 +285,8 @@ class _EscapeCodeCache(Dict[Attrs, str]):
 
         if bold:
             parts.append("1")
+        if dim:
+            parts.append("2")
         if italic:
             parts.append("3")
         if blink:

--- a/src/prompt_toolkit/output/win32.py
+++ b/src/prompt_toolkit/output/win32.py
@@ -293,6 +293,7 @@ class Win32Output(Output):
             blink,
             reverse,
             hidden,
+            dim,
         ) = attrs
         self._hidden = bool(hidden)
 

--- a/src/prompt_toolkit/styles/base.py
+++ b/src/prompt_toolkit/styles/base.py
@@ -29,6 +29,7 @@ class Attrs(NamedTuple):
     blink: bool | None
     reverse: bool | None
     hidden: bool | None
+    dim: bool | None
 
 
 """
@@ -41,6 +42,7 @@ class Attrs(NamedTuple):
 :param blink: Boolean
 :param reverse: Boolean
 :param hidden: Boolean
+:param dim: Boolean
 """
 
 #: The default `Attrs`.
@@ -54,6 +56,7 @@ DEFAULT_ATTRS = Attrs(
     blink=False,
     reverse=False,
     hidden=False,
+    dim=False,
 )
 
 

--- a/src/prompt_toolkit/styles/style.py
+++ b/src/prompt_toolkit/styles/style.py
@@ -88,6 +88,7 @@ _EMPTY_ATTRS = Attrs(
     blink=None,
     reverse=None,
     hidden=None,
+    dim=None,
 )
 
 
@@ -151,6 +152,10 @@ def _parse_style_str(style_str: str) -> Attrs:
             attrs = attrs._replace(hidden=True)
         elif part == "nohidden":
             attrs = attrs._replace(hidden=False)
+        elif part == "dim":
+            attrs = attrs._replace(dim=True)
+        elif part == "nodim":
+            attrs = attrs._replace(dim=False)
 
         # Pygments properties that we ignore.
         elif part in ("roman", "sans", "mono"):
@@ -345,6 +350,7 @@ def _merge_attrs(list_of_attrs: list[Attrs]) -> Attrs:
         blink=_or(False, *[a.blink for a in list_of_attrs]),
         reverse=_or(False, *[a.reverse for a in list_of_attrs]),
         hidden=_or(False, *[a.hidden for a in list_of_attrs]),
+        dim=_or(False, *[a.dim for a in list_of_attrs]),
     )
 
 

--- a/tests/test_formatted_text.py
+++ b/tests/test_formatted_text.py
@@ -89,6 +89,46 @@ def test_ansi_formatting():
     assert isinstance(to_formatted_text(value), FormattedText)
 
 
+def test_ansi_dim():
+    # Test dim formatting
+    value = ANSI("\x1b[2mhello\x1b[0m")
+
+    assert to_formatted_text(value) == [
+        ("dim", "h"),
+        ("dim", "e"),
+        ("dim", "l"),
+        ("dim", "l"),
+        ("dim", "o"),
+    ]
+
+    # Test dim with other attributes
+    value = ANSI("\x1b[1;2;31mhello\x1b[0m")
+
+    assert to_formatted_text(value) == [
+        ("ansired bold dim", "h"),
+        ("ansired bold dim", "e"),
+        ("ansired bold dim", "l"),
+        ("ansired bold dim", "l"),
+        ("ansired bold dim", "o"),
+    ]
+
+    # Test dim reset with code 22
+    value = ANSI("\x1b[1;2mhello\x1b[22mworld\x1b[0m")
+
+    assert to_formatted_text(value) == [
+        ("bold dim", "h"),
+        ("bold dim", "e"),
+        ("bold dim", "l"),
+        ("bold dim", "l"),
+        ("bold dim", "o"),
+        ("", "w"),
+        ("", "o"),
+        ("", "r"),
+        ("", "l"),
+        ("", "d"),
+    ]
+
+
 def test_ansi_256_color():
     assert to_formatted_text(ANSI("\x1b[38;5;124mtest")) == [
         ("#af0000", "t"),

--- a/tests/test_print_formatted_text.py
+++ b/tests/test_print_formatted_text.py
@@ -91,3 +91,22 @@ def test_html_with_style():
         f.data
         == "\x1b[0m\x1b[?7h\x1b[0;32mhello\x1b[0m \x1b[0;1mworld\x1b[0m\r\n\x1b[0m"
     )
+
+
+@pytest.mark.skipif(is_windows(), reason="Doesn't run on Windows yet.")
+def test_print_formatted_text_with_dim():
+    """
+    Test that dim formatting works correctly.
+    """
+    f = _Capture()
+    style = Style.from_dict(
+        {
+            "dimtext": "dim",
+        }
+    )
+    tokens = FormattedText([("class:dimtext", "dim text")])
+
+    pt_print(tokens, style=style, file=f, color_depth=ColorDepth.DEFAULT)
+
+    # Check that the ANSI dim escape code (ESC[2m) is in the output
+    assert "\x1b[0;2m" in f.data or "\x1b[2m" in f.data

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -22,6 +22,7 @@ def test_style_from_dict():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:a") == expected
 
@@ -36,6 +37,7 @@ def test_style_from_dict():
         blink=True,
         reverse=True,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:b") == expected
 
@@ -50,6 +52,7 @@ def test_style_from_dict():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("#ff0000") == expected
 
@@ -64,6 +67,7 @@ def test_style_from_dict():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:a #00ff00") == expected
 
@@ -77,6 +81,7 @@ def test_style_from_dict():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("#00ff00 class:a") == expected
 
@@ -101,6 +106,7 @@ def test_class_combinations_1():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:a class:b") == expected
     assert style.get_attrs_for_style_str("class:a,b") == expected
@@ -131,6 +137,7 @@ def test_class_combinations_2():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:a class:b") == expected
     assert style.get_attrs_for_style_str("class:a,b") == expected
@@ -147,6 +154,7 @@ def test_class_combinations_2():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:b class:a") == expected
     assert style.get_attrs_for_style_str("class:b,a") == expected
@@ -173,6 +181,7 @@ def test_substyles():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:a") == expected
 
@@ -186,6 +195,7 @@ def test_substyles():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:a.b") == expected
     assert style.get_attrs_for_style_str("class:a.b.c") == expected
@@ -201,6 +211,7 @@ def test_substyles():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:b") == expected
     assert style.get_attrs_for_style_str("class:b.a") == expected
@@ -215,6 +226,7 @@ def test_substyles():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     assert style.get_attrs_for_style_str("class:b.c") == expected
     assert style.get_attrs_for_style_str("class:b.c.d") == expected
@@ -234,6 +246,7 @@ def test_swap_light_and_dark_style_transformation():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     after = Attrs(
         color="ffbbbb",
@@ -245,6 +258,7 @@ def test_swap_light_and_dark_style_transformation():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
 
     assert transformation.transform_attrs(before) == after
@@ -260,6 +274,7 @@ def test_swap_light_and_dark_style_transformation():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
     after = Attrs(
         color="ansibrightred",
@@ -271,6 +286,7 @@ def test_swap_light_and_dark_style_transformation():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
 
     assert transformation.transform_attrs(before) == after

--- a/tests/test_style_transformation.py
+++ b/tests/test_style_transformation.py
@@ -17,6 +17,7 @@ def default_attrs():
         blink=False,
         reverse=False,
         hidden=False,
+        dim=False,
     )
 
 


### PR DESCRIPTION
This PR adds complete support for ANSI dim text styling. Previously, prompt-toolkit would strip or ignore ANSI dim formatting when processing text from Rich or other libraries that use `\x1b[2m` escape sequences. This meant that dim text would appear normal instead of faded/dimmed as intended.

---
You can test the dim functionality with this script:
```python
from prompt_toolkit.formatted_text.ansi import ANSI
from prompt_toolkit import print_formatted_text

# Test basic dim
print_formatted_text(ANSI("\x1b[2mThis text should appear dim\x1b[0m"))

# Test dim with color
print_formatted_text(ANSI("\x1b[2;31mDim red text\x1b[0m"))

# Test bold + dim combination
print_formatted_text(ANSI("\x1b[1;2;34mBold dim blue text\x1b[0m"))

# Visual comparison (side by side)
print_formatted_text(ANSI("Normal vs \x1b[2mDim\x1b[0m"))

# Test dim reset
print_formatted_text(ANSI("\x1b[1;2mBold+dim\x1b[22mnormal\x1b[0m"))
```

Using Prompt-Toolkit native styles: 
```python
from prompt_toolkit import print_formatted_text
from prompt_toolkit.formatted_text import FormattedText
from prompt_toolkit.styles import Style

style = Style.from_dict({
    'dim-text': 'dim',
    'dim-red': 'dim ansired',
    'bold-dim': 'bold dim',
    'dim-blue': 'dim ansiblue',
})

print_formatted_text(FormattedText([
    ('', 'Normal text '),
    ('class:dim-text', 'dim text '),
    ('class:dim-red', 'dim red '),
    ('class:bold-dim', 'bold dim'),
]), style=style)

# Inline styles also work
print_formatted_text(FormattedText([
    ('dim', 'This is dim '),
    ('dim ansired', 'this is dim red '),
    ('bold dim ansiblue', 'this is bold dim blue'),
]))
```

It also matches Rich's `[dim]` formatting exactly: 
```python 
import io
from rich.console import Console
from rich.text import Text
from prompt_toolkit.formatted_text.ansi import ANSI
from prompt_toolkit import print_formatted_text

console = Console(file=io.StringIO(), force_terminal=True)
console.print("This is [dim]dimmed text[/dim]")
rich_output = console.file.getvalue()

# dim formatting is preserved
print_formatted_text(ANSI(rich_output))
```