### PR TITLE
Implement flushing in Windows VT100 input

### DIFF
--- a/src/prompt_toolkit/input/win32.py
+++ b/src/prompt_toolkit/input/win32.py
@@ -104,8 +104,11 @@ class Win32Input(_Win32InputBase):
     def read_keys(self) -> list[KeyPress]:
         return list(self.console_input_reader.read())
 
-    def flush(self) -> None:
-        pass
+    def flush_keys(self) -> None:
+        if self._use_virtual_terminal_input:
+            return self.console_input_reader.flush_keys()
+        else:
+            return []
 
     @property
     def closed(self) -> bool:
@@ -634,6 +637,20 @@ class Vt100ConsoleInputReader:
         # whether we should consider this a paste event or not.
         for key_data in self._get_keys(read, input_records):
             self._vt100_parser.feed(key_data)
+
+        # Return result.
+        result = self._buffer
+        self._buffer = []
+        return result
+
+    def flush_keys(self) -> list[KeyPress]:
+        """
+        Flush pending keys and return them.
+        (Used for flushing the 'escape' key.)
+        """
+        # Flush all pending keys. (This is most important to flush the vt100
+        # 'Escape' key early when nothing else follows.)
+        self._vt100_parser.flush()
 
         # Return result.
         result = self._buffer


### PR DESCRIPTION
The flushing logic for VT100 parsing was already there, it just wasn't called by the Windows input reader for some reason.

For transparency - I copied the `flush_keys` method verbatim from `vt100.py`.