### PR TITLE
Update docs theme to Nefertiti 0.8.6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,9 +124,8 @@ autodoc_mock_imports = [
 html_theme = "sphinx_nefertiti"
 # html_theme_path = [sphinx_nefertiti.get_html_theme_path()]
 html_theme_options = {
-    "documentation_font": "Open Sans",
-    "monospace_font": "Ubuntu Mono",
-    "monospace_font_size": "1.1rem",
+    "monospace_font": "Ubuntu Sans Mono",
+    "monospace_font_size": "0.9rem",
     # "style" can take the following values: "blue", "indigo", "purple",
     # "pink", "red", "orange", "yellow", "green", "tail", and "default".
     "style": "blue",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ Sphinx>=8,<9
 wcwidth<1
 pyperclip<2
 sphinx_copybutton>=0.5.2,<1.0.0
-sphinx-nefertiti>=0.6.0
+sphinx-nefertiti>=0.8.6


### PR DESCRIPTION
* Use variable font Ubuntu Sans Mono and adapt font size.
* Table Of Content (right side panel) for the reference API page will benefit from last fix included in 0.8.6.