### PR TITLE
docs: move the logo to the sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,9 +134,10 @@ html_theme_options = {
     # Fonts are customizable (and are not retrieved online).
     # https://sphinx-nefertiti.readthedocs.io/en/latest/users-guide/customization/fonts.html
     "logo": "logo_400px.png",
+    "logo_location": "sidebar",
     "logo_alt": "python-prompt-toolkit",
-    "logo_width": "36",
-    "logo_height": "36",
+    "logo_width": "270",
+    "logo_height": "270",
     "repository_url": "https://github.com/prompt-toolkit/python-prompt-toolkit",
     "repository_name": "python-prompt-toolkit",
     "current_version": "latest",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ Sphinx>=8,<9
 wcwidth<1
 pyperclip<2
 sphinx_copybutton>=0.5.2,<1.0.0
-sphinx-nefertiti>=0.8.6
+sphinx-nefertiti>=0.8.8


### PR DESCRIPTION
I like the logo of `prompt_toolkit`, but I don't like that it is so tiny up there in the header. 
With sphinx-nefertiti 0.8.8 it can be placed in the sidebar. 
Just in case you like it so :-)

<img width="1033" height="382" alt="Screenshot 2025-09-11 at 18 51 15" src="https://github.com/user-attachments/assets/2cee5005-ee93-429f-99f3-24cda300b5ba" />
