### PR TITLE
Clarify that patch_stdout also redirect stderr

### DIFF
--- a/src/prompt_toolkit/patch_stdout.py
+++ b/src/prompt_toolkit/patch_stdout.py
@@ -40,7 +40,7 @@ __all__ = [
 @contextmanager
 def patch_stdout(raw: bool = False) -> Generator[None, None, None]:
     """
-    Replace `sys.stdout` by an :class:`_StdoutProxy` instance.
+    Replace `sys.stdout` and `sys.stderr` by an :class:`_StdoutProxy` instance.
 
     Writing to this proxy will make sure that the text appears above the
     prompt, and that it doesn't destroy the output from the renderer.  If no
@@ -51,6 +51,9 @@ def patch_stdout(raw: bool = False) -> Generator[None, None, None]:
         then make sure that the context manager is applied after the event loop
         is changed. Printing to stdout will be scheduled in the event loop
         that's active when the context manager is created.
+
+    Warning: In order for all text to appear above the prompt `stderr` will also
+        be redirected to the stdout proxy.
 
     :param raw: (`bool`) When True, vt100 terminal escape sequences are not
                 removed/escaped.


### PR DESCRIPTION
It was not super clear to me, and triggered a minor issue in a project, where logs in non-interactive mode were redirected to stdout as well.