### PR TITLE
DEP: set missing minimal requirement on wcwidth (require >=0.1.4 as the first version with a wheel)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "wcwidth",
+    "wcwidth>=0.1.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
For context: I'm hunting down a bare minimal set of dependencies (including transitive ones) for astropy and ipython
In particular I'm trying to avoid building anything from source where possible, hence this arbitrary (yet seemingly compatible) minimal requirement I'm proposing.

xref https://github.com/ipython/ipython/pull/15054
