### PR TITLE
Don't add newline when pasting into empty buffer

### DIFF
--- a/src/prompt_toolkit/key_binding/bindings/vi.py
+++ b/src/prompt_toolkit/key_binding/bindings/vi.py
@@ -776,11 +776,16 @@ def load_vi_bindings() -> KeyBindingsBase:
         """
         Paste after
         """
+        old_buffer_text = event.current_buffer.text
         event.current_buffer.paste_clipboard_data(
             event.app.clipboard.get_data(),
             count=event.arg,
             paste_mode=PasteMode.VI_AFTER,
         )
+        if not old_buffer_text and event.current_buffer.text.startswith("\n"):
+            # Special case: when pasting into an empty buffer, remove the
+            # leading newline that gets added by the VI_AFTER paste mode.
+            event.current_buffer.text = event.current_buffer.text[1:]
 
     @handle("P", filter=vi_navigation_mode)
     def _paste_before(event: E) -> None:


### PR DESCRIPTION
In VI mode, hen I paste from the clipboard something that was copied line-style, (e.g. with `yy`, or `ggVGd`), the pasting process leaves an empty line above the pasted content. While that may be the expected behaviour, as pasting a linewise selection (with `p`) pastes it below generally, I'd argue for an exception in this case. I suggest that when pasting a command into an empty buffer, line-wise or otherwise, folks don't actually want a blank line on top that's not part of the actual copied text. This edits the vi-mode binding for `p` so that it doesn't leave an initial newline when pasting into the empty buffer (it does however, leave any newlines _that were already in the selection_, since they were intentionally copied (presumably). I think this should be implemented as the default behavior. Hope submitting a pull request is the right way to suggest this change! If not, please let me know. Thanks!
