### PR TITLE
Add some values to enum Keys

### DIFF
--- a/src/prompt_toolkit/input/ansi_escape_sequences.py
+++ b/src/prompt_toolkit/input/ansi_escape_sequences.py
@@ -126,9 +126,11 @@ ANSI_SEQUENCES: dict[str, Keys | tuple[Keys, ...]] = {
     # Ref: https://invisible-island.net/xterm/modified-keys.html
     # These are currently unsupported, so just re-map some common ones to the
     # unmodified versions
-    "\x1b[27;2;13~": Keys.ControlM,  # Shift + Enter
-    "\x1b[27;5;13~": Keys.ControlM,  # Ctrl + Enter
-    "\x1b[27;6;13~": Keys.ControlM,  # Ctrl + Shift + Enter
+    "\x1b[27;2;13~": Keys.ShiftEnter,  # Shift + Enter
+    "\x1b[27;5;13~": Keys.ControlEnter,  # Ctrl + Enter
+    "\x1b[27;6;13~": Keys.ControlShiftEnter,  # Ctrl + Shift + Enter
+    "\x1b[27;7;13~": (Keys.Escape, Keys.ControlEnter),
+    "\x1b[27;8;13~": (Keys.Escape, Keys.ControlShiftEnter),
     # --
     # Control + function keys.
     "\x1b[1;5P": Keys.ControlF1,

--- a/src/prompt_toolkit/keys.py
+++ b/src/prompt_toolkit/keys.py
@@ -22,6 +22,9 @@ class Keys(str, Enum):
     ShiftEscape = "s-escape"
 
     ControlAt = "c-@"  # Also Control-Space.
+    ControlEnter = "c-enter"
+    ControlShiftEnter = "c-s-enter"
+    ShiftEnter = "s-enter"
 
     ControlA = "c-a"
     ControlB = "c-b"


### PR DESCRIPTION
Fix #2006.
Although Keys.ShiftEnter, Keys.ControlEnter, Keys.ControlShiftEnter cannot work,
(Keys.Escape, Keys.ControlEnter) and (Keys.Escape, Keys.ControlShiftEnter) can work.
Before this PR, we have to:

    @add_key_binding(Keys.Escape, *"[27;8;13~")
    def _(event: KeyPressEvent) -> None:
        ...

Now we can:

    @add_key_binding(Keys.Escape, Keys.ControlShiftEnter)
    def _(event: KeyPressEvent) -> None:
        ...
