### PR TITLE
Include affe text editor in projects

### DIFF
--- a/PROJECTS.rst
+++ b/PROJECTS.rst
@@ -53,6 +53,7 @@ Full screen applications:
 - `Hummingbot <https://github.com/CoinAlpha/hummingbot>`_: A Cryptocurrency Algorithmic Trading Platform
 - `git-bbb <https://github.com/MrMino/git-bbb>`_: A `git blame` browser.
 - `ass <https://github.com/mlang/ass>`_: An OpenAI Assistants API client.
+- `affe <https://affe.sh>`_: A user-friendly text editor with syntax highlighting and git integration.
 
 Libraries:
 


### PR DESCRIPTION
I wrote a simple text editor using the awesome prompt_toolkit, thought it might be worth mentioning in the `PROJECTS.rst` file.
It is called `affe` (a full-fledged editor) and aims to be very user friendly, enhanced by some fancy features like syntax highlighting and git integration.

<img width="786" height="533" alt="image" src="https://github.com/user-attachments/assets/fa5f41ae-953f-43e1-85f3-e891fbc9b9d6" />

https://affe.sh
https://github.com/Leistungsabfall/affe