### PR TITLE
Fix: handle surrogate pairs in FileHistory.store_string

### DIFF
--- a/src/prompt_toolkit/history.py
+++ b/src/prompt_toolkit/history.py
@@ -300,7 +300,7 @@ class FileHistory(History):
         with open(self.filename, "ab") as f:
 
             def write(t: str) -> None:
-                f.write(t.encode("utf-8"))
+                f.write(t.encode("utf-8", errors="replace"))
 
             write(f"\n# {datetime.datetime.now()}\n")
             for line in string.split("\n"):

--- a/src/prompt_toolkit/widgets/base.py
+++ b/src/prompt_toolkit/widgets/base.py
@@ -209,7 +209,7 @@ class TextArea:
         if input_processors is None:
             input_processors = []
 
-        # Writeable attributes.
+        # Writable attributes.
         self.completer = completer
         self.complete_while_typing = complete_while_typing
         self.lexer = lexer


### PR DESCRIPTION
## Summary

Fix `FileHistory.store_string` to gracefully handle surrogate pairs in input strings by using `errors="replace"` when encoding to UTF-8.

## Problem

`FileHistory.store_string` crashes with `UnicodeEncodeError` when the input string contains surrogate pairs (e.g., `\ud83d\udc3a` from Windows clipboard). This commonly occurs on Windows when users paste text containing emoji from certain applications.

## Solution

Add `errors="replace"` to the UTF-8 encoding call, which replaces invalid surrogates with the Unicode replacement character (U+FFFD) instead of raising an exception.

## Test

```python
from prompt_toolkit.history import FileHistory

history = FileHistory("/tmp/test_history")
# Before: UnicodeEncodeError
# After: Works, surrogate replaced with \ufffd
history.append_string("\udead")
```

Fixes #2061