### PR TITLE
Fix FuzzyWordCompleter meta_dict type hint to match WordCompleter

### DIFF
--- a/src/prompt_toolkit/completion/fuzzy_completer.py
+++ b/src/prompt_toolkit/completion/fuzzy_completer.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Iterable, Sequence
-from typing import NamedTuple, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import NamedTuple
 
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import FilterOrBool, to_filter

--- a/src/prompt_toolkit/completion/fuzzy_completer.py
+++ b/src/prompt_toolkit/completion/fuzzy_completer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Iterable, Sequence
-from typing import NamedTuple
+from typing import NamedTuple, Mapping
 
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import FilterOrBool, to_filter
@@ -189,7 +189,7 @@ class FuzzyWordCompleter(Completer):
     def __init__(
         self,
         words: Sequence[str] | Callable[[], Sequence[str]],
-        meta_dict: dict[str, str] | None = None,
+        meta_dict: Mapping[str, AnyFormattedText] | None = None,
         WORD: bool = False,
     ) -> None:
         self.words = words

--- a/src/prompt_toolkit/widgets/base.py
+++ b/src/prompt_toolkit/widgets/base.py
@@ -209,7 +209,7 @@ class TextArea:
         if input_processors is None:
             input_processors = []
 
-        # Writeable attributes.
+        # Writable attributes.
         self.completer = completer
         self.complete_while_typing = complete_while_typing
         self.lexer = lexer


### PR DESCRIPTION
Fixes #2039.

`FuzzyWordCompleter` types `meta_dict` as `dict[str, str] | None` and then forwards it straight into `WordCompleter`, which declares the same parameter as `Mapping[str, AnyFormattedText] | None`. So the wrapper rejects values the wrapped class would happily accept — passing in something like `{"alpha": HTML("<b>first</b>")}` works at runtime but trips the type checker.

Widened it to match `WordCompleter`. `AnyFormattedText` is already imported in this file, just needed to add `Mapping` from typing. No runtime behavior change.