### PR TITLE
Handle asyncio.CancelledError in SSH session interaction

### DIFF
--- a/src/prompt_toolkit/contrib/ssh/server.py
+++ b/src/prompt_toolkit/contrib/ssh/server.py
@@ -34,13 +34,11 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
         self.app_session: AppSession | None = None
 
         # PipInput object, for sending input in the CLI.
-        # (This is something that we can use in the prompt_toolkit event loop,
-        # but still write date in manually.)
+        # (This is something that we can use in the prompt_toolkit event loop, but still write data in manually.)
         self._input: PipeInput | None = None
         self._output: Vt100_Output | None = None
 
-        # Output object. Don't render to the real stdout, but write everything
-        # in the SSH channel.
+        # Output object. Don't render to the real stdout, but write everything in the SSH channel.
         class Stdout:
             def write(s, data: str) -> None:
                 try:
@@ -87,8 +85,7 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
             raise Exception("`_interact` called before `connection_made`.")
 
         if hasattr(self._chan, "set_line_mode") and self._chan._editor is not None:
-            # Disable the line editing provided by asyncssh. Prompt_toolkit
-            # provides the line editing.
+            # Disable the line editing provided by asyncssh. Prompt_toolkit provides the line editing.
             self._chan.set_line_mode(False)
 
         term = self._chan.get_terminal_type()
@@ -100,14 +97,25 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
         with create_pipe_input() as self._input:
             with create_app_session(input=self._input, output=self._output) as session:
                 self.app_session = session
+
                 try:
                     await self.interact(self)
-                except BaseException:
+
+                except asyncio.CancelledError:
+                    # Expected during disconnect/shutdown.
+                    pass
+
+                except Exception:
+                    # Unexpected application error.
                     traceback.print_exc()
+
                 finally:
                     # Close the connection.
-                    self._chan.close()
-                    self._input.close()
+                    if self._chan is not None:
+                        self._chan.close()
+
+                    if self._input is not None:
+                        self._input.close()
 
     def terminal_size_changed(
         self, width: int, height: int, pixwidth: object, pixheight: object
@@ -176,4 +184,7 @@ class PromptToolkitSSHServer(asyncssh.SSHServer):
         return False
 
     def session_requested(self) -> PromptToolkitSSHSession:
-        return PromptToolkitSSHSession(self.interact, enable_cpr=self.enable_cpr)
+        return PromptToolkitSSHSession(
+            self.interact,
+            enable_cpr=self.enable_cpr,
+        )

--- a/src/prompt_toolkit/contrib/ssh/server.py
+++ b/src/prompt_toolkit/contrib/ssh/server.py
@@ -188,3 +188,4 @@ class PromptToolkitSSHServer(asyncssh.SSHServer):
             self.interact,
             enable_cpr=self.enable_cpr,
         )
+    

--- a/src/prompt_toolkit/contrib/ssh/server.py
+++ b/src/prompt_toolkit/contrib/ssh/server.py
@@ -34,11 +34,13 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
         self.app_session: AppSession | None = None
 
         # PipInput object, for sending input in the CLI.
-        # (This is something that we can use in the prompt_toolkit event loop, but still write data in manually.)
+        # (This is something that we can use in the prompt_toolkit event loop,
+        # but still write date in manually.)
         self._input: PipeInput | None = None
         self._output: Vt100_Output | None = None
 
-        # Output object. Don't render to the real stdout, but write everything in the SSH channel.
+        # Output object. Don't render to the real stdout, but write everything
+        # in the SSH channel.
         class Stdout:
             def write(s, data: str) -> None:
                 try:
@@ -85,7 +87,8 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
             raise Exception("`_interact` called before `connection_made`.")
 
         if hasattr(self._chan, "set_line_mode") and self._chan._editor is not None:
-            # Disable the line editing provided by asyncssh. Prompt_toolkit provides the line editing.
+            # Disable the line editing provided by asyncssh. Prompt_toolkit
+            # provides the line editing.
             self._chan.set_line_mode(False)
 
         term = self._chan.get_terminal_type()
@@ -106,16 +109,12 @@ class PromptToolkitSSHSession(asyncssh.SSHServerSession):  # type: ignore
                     pass
 
                 except Exception:
-                    # Unexpected application error.
                     traceback.print_exc()
 
                 finally:
                     # Close the connection.
-                    if self._chan is not None:
-                        self._chan.close()
-
-                    if self._input is not None:
-                        self._input.close()
+                    self._chan.close()
+                    self._input.close()
 
     def terminal_size_changed(
         self, width: int, height: int, pixwidth: object, pixheight: object
@@ -184,8 +183,4 @@ class PromptToolkitSSHServer(asyncssh.SSHServer):
         return False
 
     def session_requested(self) -> PromptToolkitSSHSession:
-        return PromptToolkitSSHSession(
-            self.interact,
-            enable_cpr=self.enable_cpr,
-        )
-    
+        return PromptToolkitSSHSession(self.interact, enable_cpr=self.enable_cpr)


### PR DESCRIPTION
Fixes noisy traceback propagation during SSH session cancellation.

Currently `_interact()` catches `BaseException`, which also captures `asyncio.CancelledError`. In modern asyncio versions (especially Python 3.11+ / 3.13), `CancelledError` is expected control-flow during task shutdown and should not be treated as an application error.

This change:

* handles `asyncio.CancelledError` explicitly
* keeps normal application exceptions visible
* avoids traceback spam during SSH disconnect/session cancellation
* improves cancellation behavior when pressing `Ctrl-C` during the asyncssh example progress demo

Related issue: #1991
