### PR TITLE
Ensure confirm() returns a boolean after Enter

### DIFF
--- a/src/prompt_toolkit/application/application.py
+++ b/src/prompt_toolkit/application/application.py
@@ -1055,8 +1055,6 @@ class Application(Generic[_AppResult]):
         import pdb
         from types import FrameType
 
-        TraceDispatch = Callable[[FrameType, str, Any], Any]
-
         @contextmanager
         def hide_app_from_eventloop_thread() -> Generator[None, None, None]:
             """Stop application if `__breakpointhook__` is called from within
@@ -1110,9 +1108,7 @@ class Application(Generic[_AppResult]):
                 done.set()
 
         class CustomPdb(pdb.Pdb):
-            def trace_dispatch(
-                self, frame: FrameType, event: str, arg: Any
-            ) -> TraceDispatch:
+            def trace_dispatch(self, frame: FrameType, event: str, arg: Any) -> Any:
                 if app._loop_thread is None:
                     return super().trace_dispatch(frame, event, arg)
 

--- a/src/prompt_toolkit/shortcuts/prompt.py
+++ b/src/prompt_toolkit/shortcuts/prompt.py
@@ -1527,6 +1527,11 @@ def create_confirm_session(
         session.default_buffer.text = "n"
         event.app.exit(result=False)
 
+    @bindings.add("enter")
+    def _(event: E) -> None:
+        "Disallow submitting without an answer."
+        pass
+
     @bindings.add(Keys.Any)
     def _(event: E) -> None:
         "Disallow inserting other text."

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
-from prompt_toolkit.shortcuts import print_container
-from prompt_toolkit.shortcuts.prompt import _split_multiline_prompt
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+from prompt_toolkit.shortcuts import confirm, print_container
+from prompt_toolkit.shortcuts.prompt import PromptSession, _split_multiline_prompt
 from prompt_toolkit.widgets import Frame, TextArea
 
 
@@ -66,3 +73,18 @@ def test_print_container(tmpdir):
         text = fd.read()
         assert "Hello world" in text
         assert "Title" in text
+
+
+@pytest.mark.parametrize(
+    ("answer", "expected"),
+    [("y", True), ("Y", True), ("n", False), ("N", False)],
+)
+def test_confirm_ignores_enter_without_answer(answer, expected):
+    with create_pipe_input() as input:
+        input.send_text(f"\r{answer}")
+        session = partial(PromptSession, input=input, output=DummyOutput())
+
+        with patch("prompt_toolkit.shortcuts.prompt.PromptSession", session):
+            result = confirm()
+
+    assert result is expected

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from importlib import import_module
 from unittest.mock import patch
 
 import pytest
@@ -83,8 +84,9 @@ def test_confirm_ignores_enter_without_answer(answer, expected):
     with create_pipe_input() as input:
         input.send_text(f"\r{answer}")
         session = partial(PromptSession, input=input, output=DummyOutput())
+        prompt_module = import_module("prompt_toolkit.shortcuts.prompt")
 
-        with patch("prompt_toolkit.shortcuts.prompt.PromptSession", session):
+        with patch.object(prompt_module, "PromptSession", session):
             result = confirm()
 
     assert result is expected


### PR DESCRIPTION
## Summary

Fix `prompt_toolkit.shortcuts.confirm()` returning an empty string when Enter is pressed without selecting an answer.

Enter previously fell through to `PromptSession`'s normal accept binding, which returned the empty buffer contents. The confirmation session now handles Enter explicitly and continues waiting for `y` or `n`, so successful results remain `True` or `False`.

The CI environment's current mypy/typeshed versions also exposed an incompatible return annotation in the existing custom PDB trace dispatcher. Its internal return annotation is now `Any`, matching the range of values accepted by the debugger API without changing runtime behavior.

Fixes #2046.

## Tests

- Added regression coverage for Enter followed by `y`, `Y`, `n`, and `N`
- `.venv\Scripts\python.exe -m pytest tests/test_shortcuts.py -q -k confirm`
- `ruff check src/prompt_toolkit/shortcuts/prompt.py tests/test_shortcuts.py`
- `ruff format --check src/prompt_toolkit/shortcuts/prompt.py tests/test_shortcuts.py`
- Strict mypy check for the changed implementation
- `typos .`

## AI disclosure

OpenCode using `myself/gpt-5.6-sol` assisted with issue investigation, implementation, and test preparation. I reviewed the change and verification results.
