### PR TITLE
fix: update return types of dialog shortcuts to include None when cancelled

### DIFF
--- a/src/prompt_toolkit/shortcuts/dialogs.py
+++ b/src/prompt_toolkit/shortcuts/dialogs.py
@@ -113,7 +113,7 @@ def input_dialog(
     password: FilterOrBool = False,
     style: BaseStyle | None = None,
     default: str = "",
-) -> Application[str]:
+) -> Application[str | None]:
     """
     Display a text input box.
     Return the given text, or None when cancelled.
@@ -182,7 +182,7 @@ def radiolist_dialog(
     values: Sequence[tuple[_T, AnyFormattedText]] | None = None,
     default: _T | None = None,
     style: BaseStyle | None = None,
-) -> Application[_T]:
+) -> Application[_T | None]:
     """
     Display a simple list of element the user can choose amongst.
 
@@ -221,7 +221,7 @@ def checkboxlist_dialog(
     values: Sequence[tuple[_T, AnyFormattedText]] | None = None,
     default_values: Sequence[_T] | None = None,
     style: BaseStyle | None = None,
-) -> Application[list[_T]]:
+) -> Application[list[_T] | None]:
     """
     Display a simple list of element the user can choose multiple values amongst.
 


### PR DESCRIPTION
### Summary
The return types of `input_dialog`, `radiolist_dialog`, and `checkboxlist_dialog` shortcuts did not account for the case where the user cancels the dialog. 
When cancelled, these dialogs return `None`, but their return types were typed as `Application[str]`, `Application[_T]`, and
 `Application[list[_T]]` respectively.
    
This PR updates their return types to:
- `input_dialog`: `Application[str | None]`
- `radiolist_dialog`: `Application[_T | None]`
- `checkboxlist_dialog`: `Application[list[_T] | None]`
    
This allows type checkers like mypy/pyright to correctly type-check code that handles dialog cancellation.
    
### How to Test / Reproduction

Run your type checker (e.g., `mypy`) against the attached reproduction script `dialog_tester.py`. It should type-check successfully without errors.

[dialog_tester.py](https://github.com/user-attachments/files/30351301/dialog_tester.py)
