### PR TITLE
Restore Ctrl-Y yank in Vi insert mode

### DIFF
--- a/src/prompt_toolkit/key_binding/bindings/vi.py
+++ b/src/prompt_toolkit/key_binding/bindings/vi.py
@@ -544,12 +544,21 @@ def load_vi_bindings() -> KeyBindingsBase:
             b.start_completion(select_last=True)
 
     @handle("c-g", filter=vi_insert_mode)
-    @handle("c-y", filter=vi_insert_mode)
     def _accept_completion(event: E) -> None:
         """
         Accept current completion.
         """
         event.current_buffer.complete_state = None
+
+    @handle("c-y", filter=vi_insert_mode)
+    def _accept_completion_or_yank(event: E) -> None:
+        """
+        Accept current completion, or yank when no completion is active.
+        """
+        if event.current_buffer.complete_state is None:
+            get_by_name("yank").handler(event)
+        else:
+            event.current_buffer.complete_state = None
 
     @handle("c-e", filter=vi_insert_mode)
     def _cancel_completion(event: E) -> None:

--- a/tests/test_vi_insert_bindings.py
+++ b/tests/test_vi_insert_bindings.py
@@ -4,6 +4,7 @@ from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.shortcuts import PromptSession
 
@@ -47,3 +48,23 @@ def test_ctrl_y_still_accepts_active_completion_in_vi_insert_mode():
 
     assert result == "hello"
     assert clipboard.get_data().text == "clipboard text"
+
+
+def test_custom_ctrl_y_binding_overrides_vi_default():
+    bindings = KeyBindings()
+
+    @bindings.add("c-y")
+    def custom_ctrl_y(event):
+        event.current_buffer.insert_text("CUSTOM")
+
+    with create_pipe_input() as inp:
+        inp.send_text("\x19\r")
+        session = PromptSession(
+            input=inp,
+            output=DummyOutput(),
+            editing_mode=EditingMode.VI,
+            key_bindings=bindings,
+        )
+        result = session.prompt()
+
+    assert result == "CUSTOM"

--- a/tests/test_vi_insert_bindings.py
+++ b/tests/test_vi_insert_bindings.py
@@ -1,4 +1,7 @@
-from prompt_toolkit.clipboard import InMemoryClipboard
+from prompt_toolkit.buffer import CompletionState
+from prompt_toolkit.clipboard import ClipboardData, InMemoryClipboard
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.document import Document
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output import DummyOutput
@@ -17,3 +20,30 @@ def test_ctrl_y_yanks_text_killed_by_ctrl_u_in_vi_insert_mode():
         result = session.prompt()
 
     assert result == "hello"
+
+
+def test_ctrl_y_still_accepts_active_completion_in_vi_insert_mode():
+    clipboard = InMemoryClipboard(ClipboardData("clipboard text"))
+
+    with create_pipe_input() as inp:
+        inp.send_text("\x19\r")
+        session = PromptSession(
+            input=inp,
+            output=DummyOutput(),
+            editing_mode=EditingMode.VI,
+            clipboard=clipboard,
+        )
+
+        def activate_completion() -> None:
+            buffer = session.default_buffer
+            buffer.document = Document("he", 2)
+            buffer.complete_state = CompletionState(
+                buffer.document,
+                [Completion("hello", start_position=-2)],
+            )
+            buffer.go_to_completion(0)
+
+        result = session.prompt(pre_run=activate_completion)
+
+    assert result == "hello"
+    assert clipboard.get_data().text == "clipboard text"

--- a/tests/test_vi_insert_bindings.py
+++ b/tests/test_vi_insert_bindings.py
@@ -1,0 +1,19 @@
+from prompt_toolkit.clipboard import InMemoryClipboard
+from prompt_toolkit.enums import EditingMode
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+from prompt_toolkit.shortcuts import PromptSession
+
+
+def test_ctrl_y_yanks_text_killed_by_ctrl_u_in_vi_insert_mode():
+    with create_pipe_input() as inp:
+        inp.send_text("hello\x15\x19\r")
+        session = PromptSession(
+            input=inp,
+            output=DummyOutput(),
+            editing_mode=EditingMode.VI,
+            clipboard=InMemoryClipboard(),
+        )
+        result = session.prompt()
+
+    assert result == "hello"


### PR DESCRIPTION
## Summary

In Vi insert mode, `Ctrl-U` uses the Readline-style `unix-line-discard` binding, but `Ctrl-Y` is always consumed by the Vi completion handler even when no completion is active. This prevents yanking text killed by `Ctrl-U`.

This change keeps the existing `Ctrl-Y` completion behavior when a completion is active, and falls back to the Readline `yank` command otherwise. Application-defined `Ctrl-Y` bindings continue to override the default Vi binding.

This also addresses the behavior reported downstream in dbcli/pgcli#1608.

## Testing

- regression tests for yank, active completion, and custom binding precedence
- full test suite on Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.14t
- `mypy --strict` for win32, linux, and darwin across the matrix
- Ruff check / format check and typos on Python 3.14